### PR TITLE
Update jackson-module-scala dependency version

### DIFF
--- a/transportable-udfs-test/transportable-udfs-test-spark/build.gradle
+++ b/transportable-udfs-test/transportable-udfs-test-spark/build.gradle
@@ -12,6 +12,6 @@ dependencies {
   compile(group: project.ext.'spark-group', name: 'spark-sql_2.11', version: project.ext.'spark-version') {
     exclude module: 'jackson-module-paranamer'
   }
-  compile('com.fasterxml.jackson.module:jackson-module-paranamer:2.6.7')
+  compile('com.fasterxml.jackson.module:jackson-module-scala_2.11:2.7.9')
   compile 'org.testng:testng:6.11'
 }


### PR DESCRIPTION
`jackson-module-scala` and `jackson-module-paranamer` need to have the same minor version due to API incompatibilities between jackson minor versions. Spark (Core/SQL) brings in `jackson-module-scala:2.6.7.1` which brings in `jackson-module-paranamer:2.7.9` thus introducing incompatibility. Previously we pulled down `jackson-module-paranamer` to 2.6.7 to fix this issue. However if there is another dependency which requires `2.7.9` of `jackson-module-paranamer`, it will be pulled up again due to gradle dependency resolution leading to the below issue. It is better to pull up the version of `jackson-module-scala` instead.
```
Caused by:
        com.fasterxml.jackson.databind.JsonMappingException: Incompatible Jackson version: 2.7.9
            at com.fasterxml.jackson.module.scala.JacksonModule$class.setupModule(JacksonModule.scala:64)
            at com.fasterxml.jackson.module.scala.DefaultScalaModule.setupModule(DefaultScalaModule.scala:19)
            at com.fasterxml.jackson.databind.ObjectMapper.registerModule(ObjectMapper.java:730)
            at org.apache.spark.rdd.RDDOperationScope$.<init>(RDDOperationScope.scala:82)
            at org.apache.spark.rdd.RDDOperationScope$.<clinit>(RDDOperationScope.scala)
            ... 49 more
```