### PR TITLE
Fix shading issues in generated Spark artifacts

### DIFF
--- a/transportable-udfs-codegen/src/main/resources/wrapper-templates/spark
+++ b/transportable-udfs-codegen/src/main/resources/wrapper-templates/spark
@@ -3,7 +3,8 @@ package ${wrapperPackage}
 import java.util
 import com.google.common.collect.ImmutableList
 import com.linkedin.transport.api.udf.{StdUDF, TopLevelStdUDF}
-import com.linkedin.transport.spark.StdUdfWrapper
+import com.linkedin.transport.spark.{SparkStdUDF, StdUDFRegistration, StdUdfWrapper}
+import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.expressions.Expression
 
 
@@ -14,4 +15,15 @@ case class ${wrapperClass}(expressions: Seq[Expression]) extends StdUdfWrapper(e
   override protected def getStdUdfImplementations: util.List[_ <: StdUDF] = ImmutableList.of(
     ${udfImplementations}
   )
+}
+
+object ${wrapperClass} {
+
+  def register(name: String): SparkStdUDF = {
+    StdUDFRegistration.register(name, classOf[${wrapperClass}])
+  }
+
+  def register(name: String, session: SparkSession): SparkStdUDF = {
+    StdUDFRegistration.register(name, classOf[${wrapperClass}], session)
+  }
 }

--- a/transportable-udfs-codegen/src/test/resources/outputs/sample-udf-metadata/spark/sources/udfs/spark/OverloadedUDF.scala
+++ b/transportable-udfs-codegen/src/test/resources/outputs/sample-udf-metadata/spark/sources/udfs/spark/OverloadedUDF.scala
@@ -3,7 +3,8 @@ package udfs.spark
 import java.util
 import com.google.common.collect.ImmutableList
 import com.linkedin.transport.api.udf.{StdUDF, TopLevelStdUDF}
-import com.linkedin.transport.spark.StdUdfWrapper
+import com.linkedin.transport.spark.{SparkStdUDF, StdUDFRegistration, StdUdfWrapper}
+import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.expressions.Expression
 
 
@@ -14,4 +15,15 @@ case class OverloadedUDF(expressions: Seq[Expression]) extends StdUdfWrapper(exp
   override protected def getStdUdfImplementations: util.List[_ <: StdUDF] = ImmutableList.of(
     new udfs.OverloadedUDFInt(), new udfs.OverloadedUDFString()
   )
+}
+
+object OverloadedUDF {
+
+  def register(name: String): SparkStdUDF = {
+    StdUDFRegistration.register(name, classOf[OverloadedUDF])
+  }
+
+  def register(name: String, session: SparkSession): SparkStdUDF = {
+    StdUDFRegistration.register(name, classOf[OverloadedUDF], session)
+  }
 }

--- a/transportable-udfs-codegen/src/test/resources/outputs/sample-udf-metadata/spark/sources/udfs/spark/SimpleUDF.scala
+++ b/transportable-udfs-codegen/src/test/resources/outputs/sample-udf-metadata/spark/sources/udfs/spark/SimpleUDF.scala
@@ -3,7 +3,8 @@ package udfs.spark
 import java.util
 import com.google.common.collect.ImmutableList
 import com.linkedin.transport.api.udf.{StdUDF, TopLevelStdUDF}
-import com.linkedin.transport.spark.StdUdfWrapper
+import com.linkedin.transport.spark.{SparkStdUDF, StdUDFRegistration, StdUdfWrapper}
+import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.expressions.Expression
 
 
@@ -14,4 +15,15 @@ case class SimpleUDF(expressions: Seq[Expression]) extends StdUdfWrapper(express
   override protected def getStdUdfImplementations: util.List[_ <: StdUDF] = ImmutableList.of(
     new udfs.SimpleUDF()
   )
+}
+
+object SimpleUDF {
+
+  def register(name: String): SparkStdUDF = {
+    StdUDFRegistration.register(name, classOf[SimpleUDF])
+  }
+
+  def register(name: String, session: SparkSession): SparkStdUDF = {
+    StdUDFRegistration.register(name, classOf[SimpleUDF], session)
+  }
 }

--- a/transportable-udfs-plugin/src/main/java/com/linkedin/transport/plugin/Defaults.java
+++ b/transportable-udfs-plugin/src/main/java/com/linkedin/transport/plugin/Defaults.java
@@ -95,7 +95,7 @@ class Defaults {
           ),
           new ShadedJarPackaging(
               ImmutableList.of("org.apache.hadoop", "org.apache.spark"),
-              ImmutableList.of("com.linkedin.transport.spark.StdUDFRegistration"))
+              ImmutableList.of("com.linkedin.transport.spark.**"))
       )
   );
 

--- a/transportable-udfs-spark/build.gradle
+++ b/transportable-udfs-spark/build.gradle
@@ -4,7 +4,6 @@ dependencies {
   compile project(':transportable-udfs-api')
   compile project(':transportable-udfs-type-system')
   compile project(':transportable-udfs-utils')
-  compile('org.scala-lang:scala-library:2.11.8')
   // For spark-core and spark-sql dependencies, we exclude transitive dependency on 'jackson-module-paranamer',
   // since this is required for the LinkedIn version of spark-core and spark-sql.
   compileOnly(group: project.ext.'spark-group', name: 'spark-core_2.11', version: project.ext.'spark-version') {
@@ -14,7 +13,6 @@ dependencies {
     exclude module: 'jackson-module-paranamer'
   }
   compileOnly('com.fasterxml.jackson.module:jackson-module-paranamer:2.6.7')
-  compile('com.databricks:spark-avro_2.11:4.0.0')
   testCompile(group: project.ext.'spark-group', name: 'spark-core_2.11', version: project.ext.'spark-version') {
     exclude module: 'jackson-module-paranamer'
   }


### PR DESCRIPTION
- Do not explicitly specify Scala version, rely on Scala version coming from Spark
- Do not shade Transport's Scala classes. Relocation does not work well for Scala classes. This is because Scala injects a `@ScalaSignature` annotation with pickled signature of the class and currently no shading library handles relocation of classes names inside the signature. This causes usage of the UDFs to break when used inside the Scala REPL, because REPL depends on the signature. (Might also break inside non-REPL usages if the user relies on Scala Reflection; Java Reflection usage works)
- Provide a UDF registration helper which is decoupled from Transport's shading policy for its internal Scala classes. Example usage 
```
scala> import com.linkedin.transport.examples.spark.NumericAddFunction
scala> NumericAddFunction.register("num_add")
```
instead of 
```
scala> import com.linkedin.transport.spark.StdUDFRegistration
scala> import com.linkedin.transport.examples.spark.NumericAddFunction
scala> StdUDFRegistration.register("num_add", classOf[NumericAddFunction])
```
where we may want to shade `com.linkedin.transport.spark.StdUDFRegistration` in the future.
