### PR TITLE
Fix issues with Idea plugin and presto tests

### DIFF
--- a/transportable-udfs-plugin/build.gradle
+++ b/transportable-udfs-plugin/build.gradle
@@ -29,6 +29,7 @@ def writeVersionInfo = { file ->
     entry(key: "hive-version", value: '1.2.2')
     entry(key: "presto-version", value: '0.203')
     entry(key: "spark-version", value: '2.3.0')
+    entry(key: "scala-version", value: '2.11.8')
   }
 }
 

--- a/transportable-udfs-plugin/src/main/java/com/linkedin/transport/plugin/Defaults.java
+++ b/transportable-udfs-plugin/src/main/java/com/linkedin/transport/plugin/Defaults.java
@@ -112,7 +112,8 @@ class Defaults {
 
   private static DependencyConfiguration getDependencyConfiguration(ConfigurationType configurationType,
       String module, String platform, String classifier) {
-    return new DependencyConfiguration(configurationType, module + DEFAULT_VERSIONS.getProperty(platform + "-version")
+    return new DependencyConfiguration(configurationType, module
+        + ":" + DEFAULT_VERSIONS.getProperty(platform + "-version")
         + (classifier != null ? (":" + classifier) : ""));
   }
 }

--- a/transportable-udfs-plugin/src/main/java/com/linkedin/transport/plugin/Defaults.java
+++ b/transportable-udfs-plugin/src/main/java/com/linkedin/transport/plugin/Defaults.java
@@ -44,7 +44,10 @@ class Defaults {
   static final List<DependencyConfiguration> MAIN_SOURCE_SET_DEPENDENCY_CONFIGURATIONS = ImmutableList.of(
       getDependencyConfiguration(IMPLEMENTATION, "com.linkedin.transport:transportable-udfs-api", "transport"),
       getDependencyConfiguration(ANNOTATION_PROCESSOR, "com.linkedin.transport:transportable-udfs-annotation-processor",
-          "transport")
+          "transport"),
+      // the idea plugin needs a scala-library on the classpath when the scala plugin is applied even when there are no
+      // scala sources
+      getDependencyConfiguration(COMPILE_ONLY, "org.scala-lang:scala-library", "scala")
   );
 
   static final List<DependencyConfiguration> TEST_SOURCE_SET_DEPENDENCY_CONFIGURATIONS = ImmutableList.of(
@@ -64,7 +67,10 @@ class Defaults {
           ),
           ImmutableList.of(
               getDependencyConfiguration(RUNTIME_ONLY, "com.linkedin.transport:transportable-udfs-test-presto",
-                  "transport")
+                  "transport"),
+              // presto-main:tests is a transitive dependency of transportable-udfs-test-presto, but some POM -> IVY
+              // converters drop dependencies with classifiers, so we apply this dependency explicitly
+              getDependencyConfiguration(RUNTIME_ONLY, "com.facebook.presto:presto-main", "presto", "tests")
           ),
           new DistributionPackaging()),
       new Platform(
@@ -101,7 +107,12 @@ class Defaults {
 
   private static DependencyConfiguration getDependencyConfiguration(ConfigurationType configurationType,
       String module, String platform) {
-    return new DependencyConfiguration(configurationType,
-        module + ":" + DEFAULT_VERSIONS.getProperty(platform + "-version"));
+    return getDependencyConfiguration(configurationType, module, platform, null);
+  }
+
+  private static DependencyConfiguration getDependencyConfiguration(ConfigurationType configurationType,
+      String module, String platform, String classifier) {
+    return new DependencyConfiguration(configurationType, module + DEFAULT_VERSIONS.getProperty(platform + "-version")
+        + (classifier != null ? (":" + classifier) : ""));
   }
 }


### PR DESCRIPTION
- The idea plugin needs a scala-library on the classpath when the scala plugin is applied even when there are no scala sources. So we explicitly add the scala library as a dependency of main sourceSet.
- `presto-main:tests` is a transitive dependency of `transportable-udfs-test-presto`, but some POM to IVY converters drop dependency classifiers, so we apply this dependency explicitly.