### PR TITLE
Allow for absolute paths instead of assuming defaultFS in UDF's required files

### DIFF
--- a/transportable-udfs-hive/src/main/java/com/linkedin/transport/hive/StdUdfWrapper.java
+++ b/transportable-udfs-hive/src/main/java/com/linkedin/transport/hive/StdUdfWrapper.java
@@ -231,7 +231,7 @@ public abstract class StdUdfWrapper extends GenericUDF {
     }
     _distributedCacheFiles = Arrays.stream(requiredFiles).map(requiredFile -> {
       try {
-        return FileSystemUtils.resolveLatest(requiredFile, FileSystemUtils.getHDFSFileSystem());
+        return FileSystemUtils.resolveLatest(requiredFile);
       } catch (IOException e) {
         throw new RuntimeException("Failed to resolve path: [" + requiredFile + "].", e);
       }

--- a/transportable-udfs-presto/src/main/java/com/linkedin/transport/presto/FileSystemClient.java
+++ b/transportable-udfs-presto/src/main/java/com/linkedin/transport/presto/FileSystemClient.java
@@ -53,7 +53,7 @@ public class FileSystemClient {
       Path remotePath = new Path(remoteFilename);
       Path localPath = new Path(Paths.get(getAndCreateLocalDir(), new File(remoteFilename).getName()).toString());
       FileSystem fs = remotePath.getFileSystem(conf);
-      String resolvedRemoteFilename = FileSystemUtils.resolveLatest(remoteFilename, fs);
+      String resolvedRemoteFilename = FileSystemUtils.resolveLatest(remoteFilename);
       Path resolvedRemotePath = new Path(resolvedRemoteFilename);
       fs.copyToLocalFile(resolvedRemotePath, localPath);
       return localPath.toString();

--- a/transportable-udfs-spark/src/main/scala/com/linkedin/transport/spark/StdUdfWrapper.scala
+++ b/transportable-udfs-spark/src/main/scala/com/linkedin/transport/spark/StdUdfWrapper.scala
@@ -95,7 +95,7 @@ abstract class StdUdfWrapper(_expressions: Seq[Expression]) extends Expression
         lazy val sparkContext = SparkSession.builder().getOrCreate().sparkContext
         _distributedCacheFiles = requiredFiles.map(file => {
           try {
-            val resolvedFile = FileSystemUtils.resolveLatest(file, FileSystemUtils.getHDFSFileSystem)
+            val resolvedFile = FileSystemUtils.resolveLatest(file)
             // TODO: Currently does not support adding of files with same file name. E.g dirA/file.txt dirB/file.txt
             sparkContext.addFile(resolvedFile)
             resolvedFile

--- a/transportable-udfs-test/transportable-udfs-test-generic/src/main/java/com/linkedin/transport/test/generic/GenericStdUDFWrapper.java
+++ b/transportable-udfs-test/transportable-udfs-test-generic/src/main/java/com/linkedin/transport/test/generic/GenericStdUDFWrapper.java
@@ -196,7 +196,7 @@ public class GenericStdUDFWrapper {
     }
     _localFiles = Arrays.stream(requiredFiles).map(requiredFile -> {
       try {
-        return FileSystemUtils.resolveLatest(requiredFile, FileSystemUtils.getLocalFileSystem());
+        return FileSystemUtils.resolveLatest(requiredFile);
       } catch (IOException e) {
         throw new RuntimeException("Failed to resolve path: [" + requiredFile + "].", e);
       }

--- a/transportable-udfs-utils/src/main/java/com/linkedin/transport/utils/FileSystemUtils.java
+++ b/transportable-udfs-utils/src/main/java/com/linkedin/transport/utils/FileSystemUtils.java
@@ -40,11 +40,11 @@ public class FileSystemUtils {
   }
 
   /**
-   * Get the HDFS FileSystem
+   * Get the FileSystem for the path
    *
-   * @return the HDFS FileSystem if we are not in local mode, local FileSystem if we are.
+   * @return the Path's FileSystem if we are not in local mode, local FileSystem if we are.
    */
-  public static FileSystem getHDFSFileSystem() {
+  public static FileSystem getFileSystem(String filePath) {
     FileSystem fs;
     JobConf conf = new JobConf();
     try {
@@ -52,7 +52,7 @@ public class FileSystemUtils {
       if (isLocalEnvironment(conf)) {
         fs = FileSystem.getLocal(conf);
       } else {
-        fs = FileSystem.get(conf);
+        fs = new Path(filePath).getFileSystem(conf);
       }
     } catch (IOException e) {
       throw new RuntimeException("Failed to load the HDFS file system.", e);
@@ -87,16 +87,15 @@ public class FileSystemUtils {
    * the same path.
    *
    * @param path the path to resolve
-   * @param fs the filesystem used to resolve the path
    * @return the resolved path
    * @throws IOException when the filesystem could not resolve the path
    */
-  public static String resolveLatest(String path, FileSystem fs) throws IOException {
+  public static String resolveLatest(String path) throws IOException {
     if (!StringUtils.isBlank(path)) {
       path = path.trim();
       String[] split = path.split("#LATEST");
       String retval = split[0];
-
+      FileSystem fs = getFileSystem(path);
       for (int i = 1; i < split.length; ++i) {
         retval = resolveLatestHelper(retval, fs, true) + split[i];
       }

--- a/transportable-udfs-utils/src/test/java/com/linkedin/transport/utils/FileSystemUtilsTest.java
+++ b/transportable-udfs-utils/src/test/java/com/linkedin/transport/utils/FileSystemUtilsTest.java
@@ -18,20 +18,18 @@ public class FileSystemUtilsTest {
 
   @Test
   public void testResolveLatest() throws IOException, URISyntaxException {
-    FileSystem fs = FileSystemUtils.getLocalFileSystem();
-
-    String resourcePath = getPathForResource("root");
+    String resourcePath = "file://" + getPathForResource("root");
 
     // Test cases to resolve #LATEST
-    String filePath = FileSystemUtils.resolveLatest(resourcePath + "/2018/11/02.dat", fs);
+    String filePath = FileSystemUtils.resolveLatest(resourcePath + "/2018/11/02.dat");
     Assert.assertTrue(
-        FileSystemUtils.resolveLatest(resourcePath + "/2018/11/02.dat", fs).endsWith("/root/2018/11/02.dat"));
+        FileSystemUtils.resolveLatest(resourcePath + "/2018/11/02.dat").endsWith("/root/2018/11/02.dat"));
     Assert.assertTrue(
-        FileSystemUtils.resolveLatest(resourcePath + "/#LATEST/11/#LATEST", fs).endsWith("/root/2019/11/02.dat"));
+        FileSystemUtils.resolveLatest(resourcePath + "/#LATEST/11/#LATEST").endsWith("/root/2019/11/02.dat"));
     Assert.assertTrue(
-        FileSystemUtils.resolveLatest(resourcePath + "/#LATEST/#LATEST/#LATEST", fs).endsWith("/root/2019/12/02.dat"));
+        FileSystemUtils.resolveLatest(resourcePath + "/#LATEST/#LATEST/#LATEST").endsWith("/root/2019/12/02.dat"));
     Assert.assertTrue(
-        FileSystemUtils.resolveLatest(resourcePath + "/#LATEST/#LATEST", fs).endsWith("/root/2019/13.dat"));
+        FileSystemUtils.resolveLatest(resourcePath + "/#LATEST/#LATEST").endsWith("/root/2019/13.dat"));
   }
 
   private String getPathForResource(String resource) throws URISyntaxException {


### PR DESCRIPTION
Problem statement: I want fully qualified URIs to work in required files function of a UDF. Currently, to resolve #LATEST, the code assumes that the filesystem in use is coming from the configuration option fs.defaultFS. This change does by switching usages of FileSystem.get(conf) to FileSystem.get(URI, conf). This change is similar to the internal RB (rb no. 1901530) I posted recently. 

Following steps were used for testing:
1. setting defaultFS to an abfs directory 
2. setting the protocol to be file:/// in unit tests. 
3. running the FileSystemUtilTest