### PR TITLE
Disable Jacoco for platform tests

### DIFF
--- a/transportable-udfs-plugin/src/main/java/com/linkedin/transport/plugin/TransportPlugin.java
+++ b/transportable-udfs-plugin/src/main/java/com/linkedin/transport/plugin/TransportPlugin.java
@@ -60,6 +60,7 @@ public class TransportPlugin implements Plugin<Project> {
       Defaults.DEFAULT_PLATFORMS.forEach(
           platform -> configurePlatform(project, platform, mainSourceSet, testSourceSet));
     });
+    // Disable Jacoco for platform test tasks as it is known to cause issues with Presto and Hive tests
     project.getPlugins().withType(JacocoPlugin.class, (jacocoPlugin) -> {
         Defaults.DEFAULT_PLATFORMS.forEach(platform -> {
           project.getTasksByName(testTaskName(platform), true).forEach(task -> {

--- a/transportable-udfs-plugin/src/main/java/com/linkedin/transport/plugin/TransportPlugin.java
+++ b/transportable-udfs-plugin/src/main/java/com/linkedin/transport/plugin/TransportPlugin.java
@@ -25,6 +25,8 @@ import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.testing.Test;
 import org.gradle.language.base.plugins.LifecycleBasePlugin;
+import org.gradle.testing.jacoco.plugins.JacocoPlugin;
+import org.gradle.testing.jacoco.plugins.JacocoTaskExtension;
 
 import static com.linkedin.transport.plugin.ConfigurationType.*;
 import static com.linkedin.transport.plugin.SourceSetUtils.*;
@@ -57,6 +59,16 @@ public class TransportPlugin implements Plugin<Project> {
       configureBaseSourceSets(project, mainSourceSet, testSourceSet);
       Defaults.DEFAULT_PLATFORMS.forEach(
           platform -> configurePlatform(project, platform, mainSourceSet, testSourceSet));
+    });
+    project.getPlugins().withType(JacocoPlugin.class, (jacocoPlugin) -> {
+        Defaults.DEFAULT_PLATFORMS.forEach(platform -> {
+          project.getTasksByName(testTaskName(platform), true).forEach(task -> {
+            JacocoTaskExtension jacocoExtension = task.getExtensions().findByType(JacocoTaskExtension.class);
+            if (jacocoExtension != null) {
+              jacocoExtension.setEnabled(false);
+            }
+          });
+        });
     });
   }
 
@@ -230,7 +242,7 @@ public class TransportPlugin implements Plugin<Project> {
       }
     */
 
-    return project.getTasks().register(platform.getName() + "Test", Test.class, task -> {
+    return project.getTasks().register(testTaskName(platform), Test.class, task -> {
       task.setGroup(LifecycleBasePlugin.VERIFICATION_GROUP);
       task.setDescription("Runs Transport UDF tests on " + platform.getName());
       task.setTestClassesDirs(testSourceSet.getOutput().getClassesDirs());
@@ -238,5 +250,9 @@ public class TransportPlugin implements Plugin<Project> {
       task.useTestNG();
       task.mustRunAfter(project.getTasks().named("test"));
     });
+  }
+
+  private String testTaskName(Platform platform) {
+    return platform.getName() + "Test";
   }
 }


### PR DESCRIPTION
Fixes #36

Manually applied jacoco plugin to `transportable-udfs-example-udfs`

Before the change:
Presto Test for `transportable-udfs-example-udfs` fails with
```
Caused by: java.lang.IllegalArgumentException: Cannot determine size of boolean[] because it contains an array
	at io.prestosql.spi.block.BlockBuilderStatus.deepInstanceSize(BlockBuilderStatus.java:63)
	at io.prestosql.spi.block.BlockBuilderStatus.deepInstanceSize(BlockBuilderStatus.java:78)
	at io.prestosql.spi.block.BlockBuilderStatus.deepInstanceSize(BlockBuilderStatus.java:78)
	at io.prestosql.spi.block.BlockBuilderStatus.<clinit>(BlockBuilderStatus.java:26)
	... 81 more
```

After change:
All tests pass

After verified with the following print statements in `build.gradle` of `transportable-udfs-example-udfs`
```
project.afterEvaluate {
  println test.jacoco.enabled
  println hiveTest.jacoco.enabled
  println prestoTest.jacoco.enabled
}
```
Before change:
```
true
true
true
```
After change:
```
true
false
false
```