### PR TITLE
Presto: Pass custom configuration object when using FileSystemUtils

### DIFF
--- a/transportable-udfs-presto/src/main/java/com/linkedin/transport/presto/FileSystemClient.java
+++ b/transportable-udfs-presto/src/main/java/com/linkedin/transport/presto/FileSystemClient.java
@@ -53,7 +53,9 @@ public class FileSystemClient {
       Path remotePath = new Path(remoteFilename);
       Path localPath = new Path(Paths.get(getAndCreateLocalDir(), new File(remoteFilename).getName()).toString());
       FileSystem fs = remotePath.getFileSystem(conf);
-      String resolvedRemoteFilename = FileSystemUtils.resolveLatest(remoteFilename);
+      // It is important to pass the custom configuration object to FileSystemUtils since we load some extra
+      // properties from etc/**.xml in getConfiguration() for Presto
+      String resolvedRemoteFilename = FileSystemUtils.resolveLatest(remoteFilename, conf);
       Path resolvedRemotePath = new Path(resolvedRemoteFilename);
       fs.copyToLocalFile(resolvedRemotePath, localPath);
       return localPath.toString();

--- a/transportable-udfs-utils/src/main/java/com/linkedin/transport/utils/FileSystemUtils.java
+++ b/transportable-udfs-utils/src/main/java/com/linkedin/transport/utils/FileSystemUtils.java
@@ -14,16 +14,12 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.mapred.JobConf;
 
 /**
  * This Utils class handles multiple utilities methods related with Hadoop FileSystem.
  *
  */
 public class FileSystemUtils {
-  public static final String MAPREDUCE_FRAMEWORK_NAME = "mapreduce.framework.name";
-  public static final String MAPRED_JOB_TRACKER = "mapred.job.tracker";
-  public static final String LOCAL = "local";
 
   private FileSystemUtils() {
     // Empty on purpose
@@ -35,12 +31,18 @@ public class FileSystemUtils {
    * @return the Path's FileSystem if we are not in local mode, local FileSystem if we are.
    */
   public static FileSystem getFileSystem(String filePath) {
+    return getFileSystem(filePath, new Configuration());
+  }
+
+  /**
+   * Same as {@link #getFileSystem(String)} but allows passing a {@link Configuration} used to resolve the path
+   */
+  public static FileSystem getFileSystem(String filePath, Configuration conf) {
     FileSystem fs;
-    JobConf conf = new JobConf();
     try {
       fs = new Path(filePath).getFileSystem(conf);
     } catch (IOException e) {
-      throw new RuntimeException("Failed to load the HDFS file system.", e);
+      throw new RuntimeException("Failed to load the file system for path: " + filePath, e);
     }
 
     return fs;
@@ -76,11 +78,18 @@ public class FileSystemUtils {
    * @throws IOException when the filesystem could not resolve the path
    */
   public static String resolveLatest(String path) throws IOException {
+    return resolveLatest(path, new Configuration());
+  }
+
+  /**
+   * Same as {@link #resolveLatest(String)} but allows passing a {@link Configuration} used to resolve the path
+   */
+  public static String resolveLatest(String path, Configuration conf) throws IOException {
     if (!StringUtils.isBlank(path)) {
       path = path.trim();
       String[] split = path.split("#LATEST");
       String retval = split[0];
-      FileSystem fs = getFileSystem(path);
+      FileSystem fs = getFileSystem(path, conf);
       for (int i = 1; i < split.length; ++i) {
         retval = resolveLatestHelper(retval, fs, true) + split[i];
       }


### PR DESCRIPTION
In a3906a4bf335757d6da786db3582327379d4960a, we inadvertently changed the behaviour of FileSystemClient.java(https://github.com/linkedin/transport/commit/a3906a4bf335757d6da786db3582327379d4960a#diff-0e951023ba157de4b5b807e63e25e579L56-R56) to not pass a custom FileSystem object to FileSystemUtils. The expectation was that `new Configuration()` would provide all the necessary information to interact with DistributedFileSystem. However, for Presto, `new Configuration()` is not enough as it does not contain the necessary HDFS configs. Instead for Presto we have to explicitly load `etc/hdfs-site.xml` and `etc/core-site.xml` which are configured on our clusters.

This change reverts the behavior for Presto by passing a custom Configuration object which contains the HDFS configs.

 