### PR TITLE
Upgrade to PrestoSQL 333

### DIFF
--- a/defaultEnvironment.gradle
+++ b/defaultEnvironment.gradle
@@ -10,8 +10,8 @@ subprojects {
       url "https://conjars.org/repo"
     }
   }
-  project.ext.setProperty('presto-version', '319')
-  project.ext.setProperty('airlift-slice-version', '0.33')
+  project.ext.setProperty('presto-version', '333')
+  project.ext.setProperty('airlift-slice-version', '0.38')
   project.ext.setProperty('spark-group', 'org.apache.spark')
   project.ext.setProperty('spark-version', '2.3.0')
 }

--- a/docs/transport-udfs-presto.patch
+++ b/docs/transport-udfs-presto.patch
@@ -1,28 +1,5 @@
-diff --git a/presto-main/pom.xml b/presto-main/pom.xml
-index 83a20a23fe..02afa5310f 100644
---- a/presto-main/pom.xml
-+++ b/presto-main/pom.xml
-@@ -424,6 +424,18 @@
-                             <classpathScope>test</classpathScope>
-                         </configuration>
-                     </plugin>
-+                    <plugin>
-+                        <groupId>org.apache.maven.plugins</groupId>
-+                        <artifactId>maven-jar-plugin</artifactId>
-+                        <version>2.2</version>
-+                        <executions>
-+                            <execution>
-+                                <goals>
-+                                    <goal>test-jar</goal>
-+                                </goals>
-+                            </execution>
-+                        </executions>
-+                    </plugin>
-                 </plugins>
-             </build>
-         </profile>
 diff --git a/presto-main/src/main/java/io/prestosql/server/PluginManager.java b/presto-main/src/main/java/io/prestosql/server/PluginManager.java
-index f02ceeab03..88de943bed 100644
+index abcd001031..053c17aeed 100644
 --- a/presto-main/src/main/java/io/prestosql/server/PluginManager.java
 +++ b/presto-main/src/main/java/io/prestosql/server/PluginManager.java
 @@ -23,6 +23,7 @@ import io.prestosql.connector.ConnectorManager;
@@ -31,17 +8,17 @@ index f02ceeab03..88de943bed 100644
  import io.prestosql.metadata.MetadataManager;
 +import io.prestosql.metadata.SqlScalarFunction;
  import io.prestosql.security.AccessControlManager;
+ import io.prestosql.security.GroupProviderManager;
  import io.prestosql.server.security.PasswordAuthenticatorManager;
- import io.prestosql.spi.Plugin;
-@@ -52,6 +53,7 @@ import java.util.List;
- import java.util.ServiceLoader;
+@@ -54,6 +55,7 @@ import java.util.ServiceLoader;
  import java.util.Set;
  import java.util.concurrent.atomic.AtomicBoolean;
+ import java.util.function.Supplier;
 +import java.util.stream.Collectors;
 
  import static com.google.common.base.Preconditions.checkState;
  import static io.prestosql.metadata.FunctionExtractor.extractFunctions;
-@@ -62,8 +64,22 @@ import static java.util.Objects.requireNonNull;
+@@ -64,8 +66,22 @@ import static java.util.Objects.requireNonNull;
  @ThreadSafe
  public class PluginManager
  {
@@ -54,8 +31,8 @@ index f02ceeab03..88de943bed 100644
      private static final ImmutableList<String> SPI_PACKAGES = ImmutableList.<String>builder()
 +            // io.prestosql.metadata is required for SqlScalarFunction and FunctionRegistry classes
 +            .add("io.prestosql.metadata.")
-+            // io.prestosql.operator.scalar is required for ScalarFunctionImplementation
-+            .add("io.prestosql.operator.scalar.")
++            // io.prestosql.operator. is required for ScalarFunctionImplementation and TypeSignatureParser
++            .add("io.prestosql.operator.")
              .add("io.prestosql.spi.")
 +            // io.prestosql.type is required for TypeManager, and all supported types
 +            .add("io.prestosql.type.")
@@ -63,8 +40,8 @@ index f02ceeab03..88de943bed 100644
 +            .add("io.prestosql.util.")
              .add("com.fasterxml.jackson.annotation.")
              .add("io.airlift.slice.")
-             .add("io.airlift.units.")
-@@ -155,7 +171,21 @@ public class PluginManager
+             .add("org.openjdk.jol.")
+@@ -159,11 +175,22 @@ public class PluginManager
      {
          ServiceLoader<Plugin> serviceLoader = ServiceLoader.load(Plugin.class, pluginClassLoader);
          List<Plugin> plugins = ImmutableList.copyOf(serviceLoader);
@@ -74,32 +51,21 @@ index f02ceeab03..88de943bed 100644
 +                pluginClassLoader);
 +        List<SqlScalarFunction> sqlScalarFunctions = ImmutableList.copyOf(sqlScalarFunctionsServiceLoader);
 +
-+        checkState(!plugins.isEmpty() || !sqlScalarFunctions.isEmpty(), "No service providers of type %s or %s",
-+                Plugin.class.getName(), SqlScalarFunction.class.getName());
++        checkState(!plugins.isEmpty() || !sqlScalarFunctions.isEmpty(), "No service providers of type %s or %s", Plugin.class.getName(), SqlScalarFunction.class.getName());
 +
-+        installPlugins(plugins);
-+
-+        registerSqlScalarFunctions(sqlScalarFunctions);
-+    }
-+
-+    private void installPlugins(List<Plugin> plugins)
-+    {
          for (Plugin plugin : plugins) {
              log.info("Installing %s", plugin.getClass().getName());
-             installPlugin(plugin);
-@@ -215,6 +245,15 @@ public class PluginManager
+             installPlugin(plugin, pluginClassLoader::duplicate);
          }
-     }
-
-+    public void registerSqlScalarFunctions(List<SqlScalarFunction> sqlScalarFunctions)
-+    {
++
 +        for (SqlScalarFunction sqlScalarFunction : sqlScalarFunctions) {
-+            log.info("Registering function %s(%s)", sqlScalarFunction.getSignature().getName(), sqlScalarFunction.getSignature().getArgumentTypes().stream().map(e -> e.toString()).collect(
-+                    Collectors.joining(", ")));
++            log.info("Registering function %s(%s)",
++                    sqlScalarFunction.getFunctionMetadata().getSignature().getName(),
++                    sqlScalarFunction.getFunctionMetadata().getSignature().getArgumentTypes().stream()
++                            .map(e -> e.toString())
++                            .collect(Collectors.joining(", ")));
 +            metadataManager.addFunctions(ImmutableList.of(sqlScalarFunction));
 +        }
-+    }
-+
-     private URLClassLoader buildClassLoader(String plugin)
-             throws Exception
-     {
+     }
+
+     public void installPlugin(Plugin plugin, Supplier<ClassLoader> duplicatePluginClassLoaderFactory)

--- a/transportable-udfs-examples/build.gradle
+++ b/transportable-udfs-examples/build.gradle
@@ -33,8 +33,8 @@ subprojects {
       url "https://conjars.org/repo"
     }
   }
-  project.ext.setProperty('presto-version', '319')
-  project.ext.setProperty('airlift-slice-version', '0.33')
+  project.ext.setProperty('presto-version', '333')
+  project.ext.setProperty('airlift-slice-version', '0.38')
   project.ext.setProperty('spark-group', 'org.apache.spark')
   project.ext.setProperty('spark-version', '2.3.0')
 }

--- a/transportable-udfs-plugin/build.gradle
+++ b/transportable-udfs-plugin/build.gradle
@@ -27,7 +27,7 @@ def writeVersionInfo = { file ->
   ant.propertyfile(file: file) {
     entry(key: "transport-version", value: version)
     entry(key: "hive-version", value: '1.2.2')
-    entry(key: "presto-version", value: '319')
+    entry(key: "presto-version", value: '333')
     entry(key: "spark-version", value: '2.3.0')
     entry(key: "scala-version", value: '2.11.8')
   }

--- a/transportable-udfs-presto/src/main/java/com/linkedin/transport/presto/PrestoFactory.java
+++ b/transportable-udfs-presto/src/main/java/com/linkedin/transport/presto/PrestoFactory.java
@@ -6,6 +6,7 @@
 package com.linkedin.transport.presto;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableSet;
 import com.linkedin.transport.api.StdFactory;
 import com.linkedin.transport.api.data.StdArray;
 import com.linkedin.transport.api.data.StdBoolean;
@@ -25,18 +26,19 @@ import com.linkedin.transport.presto.data.PrestoStruct;
 import io.airlift.slice.Slices;
 import io.prestosql.metadata.BoundVariables;
 import io.prestosql.metadata.Metadata;
-import io.prestosql.metadata.Signature;
+import io.prestosql.metadata.OperatorNotFoundException;
+import io.prestosql.metadata.ResolvedFunction;
 import io.prestosql.operator.scalar.ScalarFunctionImplementation;
+import io.prestosql.spi.function.OperatorType;
 import io.prestosql.spi.type.ArrayType;
 import io.prestosql.spi.type.MapType;
 import io.prestosql.spi.type.RowType;
 import io.prestosql.spi.type.Type;
-import io.prestosql.spi.type.TypeSignature;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import static io.prestosql.metadata.SignatureBinder.*;
-
+import static io.prestosql.operator.TypeSignatureParser.parseTypeSignature;
 
 public class PrestoFactory implements StdFactory {
 
@@ -104,10 +106,14 @@ public class PrestoFactory implements StdFactory {
   @Override
   public StdType createStdType(String typeSignature) {
     return PrestoWrapper.createStdType(
-        metadata.getType(applyBoundVariables(TypeSignature.parseTypeSignature(typeSignature), boundVariables)));
+        metadata.getType(applyBoundVariables(parseTypeSignature(typeSignature, ImmutableSet.of()), boundVariables)));
   }
 
-  public ScalarFunctionImplementation getScalarFunctionImplementation(Signature signature) {
-    return metadata.getScalarFunctionImplementation(signature);
+  public ScalarFunctionImplementation getScalarFunctionImplementation(ResolvedFunction resolvedFunction) {
+    return metadata.getScalarFunctionImplementation(resolvedFunction);
+  }
+
+  public ResolvedFunction resolveOperator(OperatorType operatorType, List<? extends Type> argumentTypes) throws OperatorNotFoundException {
+    return metadata.resolveOperator(operatorType, argumentTypes);
   }
 }

--- a/transportable-udfs-presto/src/main/java/com/linkedin/transport/presto/data/PrestoMap.java
+++ b/transportable-udfs-presto/src/main/java/com/linkedin/transport/presto/data/PrestoMap.java
@@ -54,7 +54,7 @@ public class PrestoMap extends PrestoData implements StdMap {
 
     _stdFactory = stdFactory;
     _keyEqualsMethod = ((PrestoFactory) stdFactory).getScalarFunctionImplementation(
-            internalOperator(OperatorType.EQUAL, BooleanType.BOOLEAN, ImmutableList.of(_keyType, _keyType)))
+            ((PrestoFactory) stdFactory).resolveOperator(OperatorType.EQUAL, ImmutableList.of(_keyType, _keyType)))
         .getMethodHandle();
   }
 


### PR DESCRIPTION
Some major changes:
 - `SqlFunction`, `SqlScalarFunction` and `ScalarFunctionImplementation` have evolved
   in https://github.com/prestosql/presto/pull/1764
 - `Metadata::getScalarFunctionImplementation` evolved in https://github.com/prestosql/presto/pull/1039
 - Type signature parser was moved to presto-main in https://github.com/prestosql/presto/pull/1738

Tests done:
 - `./gradlew build` passes inside `transportable-udfs-examples` 
 - Tested end-to-end with Presto 333 using one of the example UDFs `array_fill`. It works well