### PR TITLE
Transport Plugin Config

### DIFF
--- a/transportable-udfs-plugin/src/main/java/com/linkedin/transport/plugin/TransportPlugin.java
+++ b/transportable-udfs-plugin/src/main/java/com/linkedin/transport/plugin/TransportPlugin.java
@@ -48,7 +48,7 @@ public class TransportPlugin implements Plugin<Project> {
 
   public void apply(Project project) {
 
-    TransportPluginConfig extension = project.getExtensions().create("transportPlugin", TransportPluginConfig.class, project);
+    TransportPluginConfig extension = project.getExtensions().create("transport", TransportPluginConfig.class, project);
 
     project.getPlugins().withType(JavaPlugin.class, (javaPlugin) -> {
       project.getPlugins().apply(ScalaPlugin.class);

--- a/transportable-udfs-plugin/src/main/java/com/linkedin/transport/plugin/TransportPlugin.java
+++ b/transportable-udfs-plugin/src/main/java/com/linkedin/transport/plugin/TransportPlugin.java
@@ -47,18 +47,21 @@ import static com.linkedin.transport.plugin.SourceSetUtils.*;
 public class TransportPlugin implements Plugin<Project> {
 
   public void apply(Project project) {
+
+    TransportPluginConfig extension = project.getExtensions().create("transportPlugin", TransportPluginConfig.class, project);
+
     project.getPlugins().withType(JavaPlugin.class, (javaPlugin) -> {
       project.getPlugins().apply(ScalaPlugin.class);
       project.getPlugins().apply(DistributionPlugin.class);
       project.getConfigurations().create(ShadowBasePlugin.getCONFIGURATION_NAME());
 
       JavaPluginConvention javaConvention = project.getConvention().getPlugin(JavaPluginConvention.class);
-      SourceSet mainSourceSet = javaConvention.getSourceSets().getByName("main");
-      SourceSet testSourceSet = javaConvention.getSourceSets().getByName("test");
+      SourceSet mainSourceSet = javaConvention.getSourceSets().getByName(extension.mainSourceSetName);
+      SourceSet testSourceSet = javaConvention.getSourceSets().getByName(extension.testSourceSetName);
 
       configureBaseSourceSets(project, mainSourceSet, testSourceSet);
       Defaults.DEFAULT_PLATFORMS.forEach(
-          platform -> configurePlatform(project, platform, mainSourceSet, testSourceSet));
+          platform -> configurePlatform(project, platform, mainSourceSet, testSourceSet, extension.outputDirFile));
     });
     // Disable Jacoco for platform test tasks as it is known to cause issues with Presto and Hive tests
     project.getPlugins().withType(JacocoPlugin.class, (jacocoPlugin) -> {
@@ -90,8 +93,9 @@ public class TransportPlugin implements Plugin<Project> {
   /**
    * Configures SourceSets, dependencies and tasks related to each Transport UDF platform
    */
-  private void configurePlatform(Project project, Platform platform, SourceSet mainSourceSet, SourceSet testSourceSet) {
-    SourceSet sourceSet = configureSourceSet(project, platform, mainSourceSet);
+  private void configurePlatform(Project project, Platform platform, SourceSet mainSourceSet, SourceSet testSourceSet,
+      File baseOutputDir) {
+    SourceSet sourceSet = configureSourceSet(project, platform, mainSourceSet, baseOutputDir);
     configureGenerateWrappersTask(project, platform, mainSourceSet, sourceSet);
     List<TaskProvider<? extends Task>> packagingTasks =
         configurePackagingTasks(project, platform, sourceSet, mainSourceSet);
@@ -107,9 +111,9 @@ public class TransportPlugin implements Plugin<Project> {
    * configurations and configures the default dependencies required for compilation and runtime of the wrapper
    * SourceSet
    */
-  private SourceSet configureSourceSet(Project project, Platform platform, SourceSet mainSourceSet) {
+  private SourceSet configureSourceSet(Project project, Platform platform, SourceSet mainSourceSet, File baseOutputDir) {
     JavaPluginConvention javaConvention = project.getConvention().getPlugin(JavaPluginConvention.class);
-    Path platformBaseDir = Paths.get(project.getBuildDir().toString(), "generatedWrappers", platform.getName());
+    Path platformBaseDir = Paths.get(baseOutputDir.toString(), "generatedWrappers", platform.getName());
     Path wrapperSourceOutputDir = platformBaseDir.resolve("sources");
     Path wrapperResourceOutputDir = platformBaseDir.resolve("resources");
 

--- a/transportable-udfs-plugin/src/main/java/com/linkedin/transport/plugin/TransportPluginConfig.java
+++ b/transportable-udfs-plugin/src/main/java/com/linkedin/transport/plugin/TransportPluginConfig.java
@@ -19,7 +19,7 @@ public class TransportPluginConfig {
    */
   private static final String MAIN_SOURCE_SET_NAME_PROP = "transport-plugin-main-source-set";
   private static final String TEST_SOURCE_SET_NAME_PROP = "transport-plugin-test-source-set";
-  private static final String OUTPUT_DIR_PROP = "transport-plugin-test-output-dir";
+  private static final String OUTPUT_DIR_PROP = "transport-plugin-output-dir";
 
   /**
    * The main source set used by the plugin.
@@ -43,7 +43,7 @@ public class TransportPluginConfig {
     mainSourceSetName = getPropertyOrDefault(project, MAIN_SOURCE_SET_NAME_PROP, "main");
     testSourceSetName = getPropertyOrDefault(project, TEST_SOURCE_SET_NAME_PROP, "test");
     outputDirFile = project.hasProperty(OUTPUT_DIR_PROP)
-        ? new File(String.join(File.separator, project.getProjectDir().toString(), project.property(OUTPUT_DIR_PROP).toString()))
+        ? project.file(project.property(OUTPUT_DIR_PROP).toString())
         : project.getBuildDir(); // Build dir by default
   }
 
@@ -52,7 +52,7 @@ public class TransportPluginConfig {
    */
   private String getPropertyOrDefault(Project project, String propertyName, String defaultValue) {
     return project.hasProperty(propertyName)
-        ? project.property(MAIN_SOURCE_SET_NAME_PROP).toString()
+        ? project.property(propertyName).toString()
         : defaultValue;
   }
 }

--- a/transportable-udfs-plugin/src/main/java/com/linkedin/transport/plugin/TransportPluginConfig.java
+++ b/transportable-udfs-plugin/src/main/java/com/linkedin/transport/plugin/TransportPluginConfig.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright 2020 LinkedIn Corporation. All rights reserved.
+ * Licensed under the BSD-2 Clause license.
+ * See LICENSE in the project root for license information.
+ */
+package com.linkedin.transport.plugin;
+
+import java.io.File;
+import org.gradle.api.Project;
+
+
+/**
+ * Custom configuration for the {@link TransportPlugin}.
+ */
+public class TransportPluginConfig {
+
+  /**
+   * Available gradle property names.
+   */
+  private static final String MAIN_SOURCE_SET_NAME_PROP = "transport-plugin-main-source-set";
+  private static final String TEST_SOURCE_SET_NAME_PROP = "transport-plugin-test-source-set";
+  private static final String OUTPUT_DIR_PROP = "transport-plugin-test-output-dir";
+
+  /**
+   * The main source set used by the plugin.
+   */
+  public String mainSourceSetName;
+  /**
+   * The test source set used by the plugin.
+   */
+  public String testSourceSetName;
+  /**
+   * The output code-gen directory, relative the to the project directory.
+   */
+  public File outputDirFile;
+
+  /**
+   * Create a config object from the gradle {@link Project}.
+   *
+   * On creation, we attempt to populate config values using gradle properties or set to default values.
+   */
+  public TransportPluginConfig(Project project) {
+    mainSourceSetName = getPropertyOrDefault(project, MAIN_SOURCE_SET_NAME_PROP, "main");
+    testSourceSetName = getPropertyOrDefault(project, TEST_SOURCE_SET_NAME_PROP, "test");
+    outputDirFile = project.hasProperty(OUTPUT_DIR_PROP)
+        ? new File(String.join(File.separator, project.getProjectDir().toString(), project.property(OUTPUT_DIR_PROP).toString()))
+        : project.getBuildDir(); // Build dir by default
+  }
+
+  /**
+   * Retrieve a string property from a gradle project if it has been set, a default value otherwise.
+   */
+  private String getPropertyOrDefault(Project project, String propertyName, String defaultValue) {
+    return project.hasProperty(propertyName)
+        ? project.property(MAIN_SOURCE_SET_NAME_PROP).toString()
+        : defaultValue;
+  }
+}


### PR DESCRIPTION
This PR introduces the ability to configure aspects of the Transport Plugin. Specifically there are 3 parameters that may be configured: 

1. the name of the "main" source set to scan for UDFs and extend (Default to "main") 
2. the name of the "test" source set to extend for platform-specific test source sets (Default to "test")
3. the output directory to place generated wrappers, w.r.t the project root (Default to project build directory) 

Since these parameters are all used immediately when the plugin is applied, using gradle extension does not appear to be a viable option to set them. Instead, these parameters are configurable using gradle project properties. Nonetheless, I've chosen to expose the config to the plugin as an extension so that configs using the extension convention can be leveraged in the future.

Access to these parameters makes it easy to chain codegen processes in a module, allowing an output source set of one task serve as the input for transport tasks. 

To test, I manually set these properties using the “transport-udfs-examples” modules and observed behavior was as expected. For example,

project.ext.setProperty('transport-plugin-main-source-set', 'main')
project.ext.setProperty('transport-plugin-test-source-set', 'test')
project.ext.setProperty('transport-plugin-output-dir', 'build')

I was able to produce output to different top level directories and change the source sets which were picked up by the plugin. I’m not sure if there are better ways to validate this; open to suggestions. 

John