### PR TITLE
Remove slf4j-log4j12 from Transport dependency graph

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,12 @@ subprojects {
 
   configurations {
     all {
+      // Transport as a library should only expose slf4j-api to its consumers and should not keep any SLF4J bindings
+      // in its dependency graph
+      // Quote from http://www.slf4j.org/faq.html#maven2
+      //   "Thus, as far as your users are concerned you are exporting slf4j-api as a transitive dependency of your
+      //    library, but not any SLF4J-binding or any underlying logging system."
+      // Our dependencies (e.g. hadoop-common) do bring in slf4j-log4j12 in their dependency graph so we exclude them
       exclude group: 'org.slf4j', module: 'slf4j-log4j12'
     }
   }

--- a/build.gradle
+++ b/build.gradle
@@ -64,8 +64,6 @@ subprojects {
     project.apply(plugin: 'checkstyle')
 
     dependencies {
-      compile 'org.slf4j:slf4j-api:1.7.25'
-
       testCompile 'org.testng:testng:6.11'
       testCompile 'org.slf4j:slf4j-simple:1.7.25'
     }

--- a/build.gradle
+++ b/build.gradle
@@ -48,11 +48,20 @@ subprojects {
     strictCheck true
   }
 
+  configurations {
+    all {
+      exclude group: 'org.slf4j', module: 'slf4j-log4j12'
+    }
+  }
+
   plugins.withType(JavaPlugin) {
     project.apply(plugin: 'checkstyle')
 
     dependencies {
+      compile 'org.slf4j:slf4j-api:1.7.25'
+
       testCompile 'org.testng:testng:6.11'
+      testCompile 'org.slf4j:slf4j-simple:1.7.25'
     }
 
     test {

--- a/transportable-udfs-test/transportable-udfs-test-spark/build.gradle
+++ b/transportable-udfs-test/transportable-udfs-test-spark/build.gradle
@@ -14,4 +14,5 @@ dependencies {
   }
   compile('com.fasterxml.jackson.module:jackson-module-scala_2.11:2.7.9')
   compile 'org.testng:testng:6.11'
+  compile 'org.slf4j:slf4j-simple:1.7.25'
 }


### PR DESCRIPTION
Transport as a library should only expose `slf4j-api` to its consumers and should not expose any SLF4J bindings.

http://www.slf4j.org/faq.html#maven2
> Thus, as far as your users are concerned you are exporting slf4j-api as a transitive dependency of your library, but not any SLF4J-binding or any underlying logging system.

Unfortunately `hadoop-common` does expose `sl4fj-log4j12` as a transitive. This can cause `StackOverflowError` if another binding is also present on the classpath. This issue seems to popup frequently in Presto tests and on the Presto cluster. We as a library, should remove the bindings from our transitives and ensure we don't introduce any ourselves.

Note that we still keep the `slf4j-simple` binding for tests and explictly for spark test framework as Spark Core and Spark SQL do not include a binding.
