### PR TITLE
Bump shipkit version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ buildscript {
 }
 
 plugins {
-  id "org.shipkit.java" version "2.0.31"
+  id "org.shipkit.java" version "2.3.4"
 }
 
 allprojects {


### PR DESCRIPTION
The two things we would be interested in with the bump
- Remove shipkit's dependence on a now deprecated Github API which will stop working in October https://github.com/mockito/shipkit/pull/871
- Update bintray plugin version which I had read reduces publish slowness https://github.com/mockito/shipkit/pull/850

Tested by running `./gradlew performRelease -PdryRun` locally