### PR TITLE
Fix test SQL generation for binary inputs

### DIFF
--- a/transportable-udfs-examples/transportable-udfs-example-udfs/src/test/java/com/linkedin/transport/examples/TestBinaryDuplicateFunction.java
+++ b/transportable-udfs-examples/transportable-udfs-example-udfs/src/test/java/com/linkedin/transport/examples/TestBinaryDuplicateFunction.java
@@ -24,16 +24,36 @@ public class TestBinaryDuplicateFunction extends AbstractStdUDFTest {
   }
 
   @Test
-  public void tesBinaryDuplicate() {
+  public void testBinaryDuplicateASCII() {
     StdTester tester = getTester();
-    tesBinaryDuplicateHelper(tester, "bar", "barbar");
-    tesBinaryDuplicateHelper(tester, "", "");
-    tesBinaryDuplicateHelper(tester, "foobar", "foobarfoobar");
+    testBinaryDuplicateStringHelper(tester, "bar", "barbar");
+    testBinaryDuplicateStringHelper(tester, "", "");
+    testBinaryDuplicateStringHelper(tester, "foobar", "foobarfoobar");
   }
 
-  private void tesBinaryDuplicateHelper(StdTester tester, String input, String expectedOutput) {
-    ByteBuffer argTest1 = ByteBuffer.wrap(input.getBytes());
+  @Test
+  public void testBinaryDuplicateUnicode() {
+    StdTester tester = getTester();
+    testBinaryDuplicateStringHelper(tester, "こんにちは世界", "こんにちは世界こんにちは世界");
+    testBinaryDuplicateStringHelper(tester, "\uD83D\uDE02", "\uD83D\uDE02\uD83D\uDE02");
+  }
+
+  private void testBinaryDuplicateStringHelper(StdTester tester, String input, String expectedOutput) {
+    ByteBuffer inputBuffer = ByteBuffer.wrap(input.getBytes());
     ByteBuffer expected = ByteBuffer.wrap(expectedOutput.getBytes());
-    tester.check(functionCall("binary_duplicate", argTest1), expected, "varbinary");
+    tester.check(functionCall("binary_duplicate", inputBuffer), expected, "varbinary");
+  }
+
+  @Test
+  public void testBinaryDuplicate() {
+    StdTester tester = getTester();
+    testBinaryDuplicateHelper(tester, new byte[] {1, 2, 3}, new byte[] {1, 2, 3, 1, 2, 3});
+    testBinaryDuplicateHelper(tester, new byte[] {-1, -2, -3}, new byte[] {-1, -2, -3, -1, -2, -3});
+  }
+
+  private void testBinaryDuplicateHelper(StdTester tester, byte[] input, byte[] expectedOutput) {
+    ByteBuffer inputBuffer = ByteBuffer.wrap(input);
+    ByteBuffer expected = ByteBuffer.wrap(expectedOutput);
+    tester.check(functionCall("binary_duplicate", inputBuffer), expected, "varbinary");
   }
 }

--- a/transportable-udfs-test/transportable-udfs-test-presto/src/main/java/com/linkedin/transport/test/presto/PrestoSqlFunctionCallGenerator.java
+++ b/transportable-udfs-test/transportable-udfs-test-presto/src/main/java/com/linkedin/transport/test/presto/PrestoSqlFunctionCallGenerator.java
@@ -9,7 +9,6 @@ import com.linkedin.transport.test.spi.Row;
 import com.linkedin.transport.test.spi.SqlFunctionCallGenerator;
 import com.linkedin.transport.test.spi.types.TestType;
 import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -35,8 +34,8 @@ public class PrestoSqlFunctionCallGenerator implements SqlFunctionCallGenerator 
 
   @Override
   public String getBinaryArgumentString(ByteBuffer value) {
-    // Note that this does not work for PrestoSQL
-    return "CAST('" + new String(value.array(), StandardCharsets.UTF_8) + "' AS VARBINARY)";
+    String base64EncodedValue = BASE64_ENCODER.encodeToString(value.array());
+    return "from_base64('" + base64EncodedValue + "')";
   }
 
   @Override

--- a/transportable-udfs-test/transportable-udfs-test-spi/src/main/java/com/linkedin/transport/test/spi/SqlFunctionCallGenerator.java
+++ b/transportable-udfs-test/transportable-udfs-test-spi/src/main/java/com/linkedin/transport/test/spi/SqlFunctionCallGenerator.java
@@ -18,7 +18,7 @@ import com.linkedin.transport.test.spi.types.StructTestType;
 import com.linkedin.transport.test.spi.types.TestType;
 import com.linkedin.transport.test.spi.types.UnknownTestType;
 import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -29,6 +29,7 @@ import java.util.stream.IntStream;
  * Creates a SQL function call string for the given function name and the function arguments
  */
 public interface SqlFunctionCallGenerator {
+  Base64.Encoder BASE64_ENCODER = Base64.getEncoder();
 
   /**
    * Returns SQL function call string of the format {@code functionName(argument1, argument2, argument3, ...)}
@@ -104,9 +105,9 @@ public interface SqlFunctionCallGenerator {
     return "CAST(" + value + " AS float)";
   }
 
-
   default String getBinaryArgumentString(ByteBuffer value) {
-    return "CAST('" + new String(value.array(), StandardCharsets.UTF_8) + "' AS BINARY)";
+    String base64EncodedValue = BASE64_ENCODER.encodeToString(value.array());
+    return "unbase64('" + base64EncodedValue + "')";
   }
 
   /**


### PR DESCRIPTION
Fixes #52 
The existing method for test binary data types (converting them to strings) does not work for unsigned byte values > 127. `new String()` will replace these bytes with Unicode replacement character https://www.fileformat.info/info/unicode/char/0fffd/index.htm

We should encode the byte values as base64 for generating the SQL string and convert them to back to binary before passing to the UDF