### PR TITLE
Row/Struct type: make space for field names

### DIFF
--- a/transportable-udfs-examples/transportable-udfs-example-udfs/src/test/java/com/linkedin/transport/examples/TestStructCreateByNameFunction.java
+++ b/transportable-udfs-examples/transportable-udfs-example-udfs/src/test/java/com/linkedin/transport/examples/TestStructCreateByNameFunction.java
@@ -26,7 +26,7 @@ public class TestStructCreateByNameFunction extends AbstractStdUDFTest {
   @Test
   public void testStructCreateByNameFunction() {
     StdTester tester = getTester();
-    tester.check(functionCall("struct_create_by_name", "a", "x", "b", "y"), row("x", "y"), "row(varchar,varchar)");
+    tester.check(functionCall("struct_create_by_name", "a", "x", "b", "y"), row("x", "y").fieldNames("a", "b"), "row(varchar, varchar)");
     tester.check(functionCall("struct_create_by_name", null, "x", "b", "y"), null, "row(varchar,varchar)");
     tester.check(functionCall("struct_create_by_name", "a", "x", null, "y"), null, "row(varchar,varchar)");
     tester.check(functionCall("struct_create_by_name", "a", null, "b", "y"), null, "row(unknown,varchar)");

--- a/transportable-udfs-test/transportable-udfs-test-spi/src/main/java/com/linkedin/transport/test/spi/Row.java
+++ b/transportable-udfs-test/transportable-udfs-test-spi/src/main/java/com/linkedin/transport/test/spi/Row.java
@@ -5,6 +5,7 @@
  */
 package com.linkedin.transport.test.spi;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
@@ -12,13 +13,23 @@ import java.util.Objects;
 public class Row {
 
   private final List<Object> _fields;
+  private List<String> _fieldNames;
 
   public Row(List<Object> fields) {
     _fields = fields;
   }
 
+  public Row fieldNames(String... fieldNames) {
+    this._fieldNames = Arrays.asList(fieldNames);
+    return this;
+  }
+
   public List<Object> getFields() {
     return _fields;
+  }
+
+  public List<String> getFieldNames() {
+    return this._fieldNames;
   }
 
   @Override
@@ -30,11 +41,31 @@ public class Row {
       return false;
     }
     Row row = (Row) o;
-    return Objects.equals(_fields, row._fields);
+    boolean isEquals = Objects.equals(_fields, row._fields);
+    if (this._fieldNames != null && row.getFieldNames() != null) {
+      // This is important. Only match fieldNames if both of the entities have provided it.
+      // We do this to allow interoperability with older code
+      isEquals = isEquals && Objects.equals(this._fieldNames, row.getFieldNames());
+    }
+    return isEquals;
   }
 
   @Override
   public int hashCode() {
     return Objects.hash(_fields);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder stringBuilder = new StringBuilder();
+    stringBuilder.append("{");
+    stringBuilder.append("fieldNames: ");
+    if (this._fieldNames != null) {
+      stringBuilder.append(_fieldNames.toString());
+    }
+    stringBuilder.append(", ");
+    stringBuilder.append("fieldValues: ");
+    stringBuilder.append(_fields.toString());
+    return stringBuilder.toString();
   }
 }

--- a/transportable-udfs-test/transportable-udfs-test-spi/src/main/java/com/linkedin/transport/test/spi/types/StringTestType.java
+++ b/transportable-udfs-test/transportable-udfs-test-spi/src/main/java/com/linkedin/transport/test/spi/types/StringTestType.java
@@ -6,4 +6,8 @@
 package com.linkedin.transport.test.spi.types;
 
 public class StringTestType implements TestType {
+  @Override
+  public String toString() {
+    return "type=string";
+  }
 }

--- a/transportable-udfs-test/transportable-udfs-test-spi/src/main/java/com/linkedin/transport/test/spi/types/StructTestType.java
+++ b/transportable-udfs-test/transportable-udfs-test-spi/src/main/java/com/linkedin/transport/test/spi/types/StructTestType.java
@@ -43,4 +43,23 @@ public class StructTestType implements TestType {
   public int hashCode() {
     return Objects.hash(_fieldNames, _fieldTypes);
   }
+
+  @Override
+  public String toString() {
+    StringBuilder stringBuilder = new StringBuilder();
+    stringBuilder.append("{ ");
+    if (_fieldNames != null) {
+      stringBuilder.append(_fieldNames.toString());
+    } else {
+      stringBuilder.append("fieldNames=null");
+    }
+    stringBuilder.append(", ");
+    if (this._fieldTypes != null) {
+      stringBuilder.append(this._fieldTypes.toString());
+    } else {
+      stringBuilder.append("_fieldTypes=null");
+    }
+    stringBuilder.append("}; ");
+    return stringBuilder.toString();
+  }
 }

--- a/transportable-udfs-test/transportable-udfs-test-spi/src/main/java/com/linkedin/transport/test/spi/types/TestTypeUtils.java
+++ b/transportable-udfs-test/transportable-udfs-test-spi/src/main/java/com/linkedin/transport/test/spi/types/TestTypeUtils.java
@@ -43,8 +43,10 @@ public class TestTypeUtils {
       return TestTypeFactory.map(inferCollectionTypeFromData(map.keySet(), "map keys"),
           inferCollectionTypeFromData(map.values(), "map values"));
     } else if (data instanceof Row) {
+      Row d = ((Row) data);
       return TestTypeFactory.struct(
-          ((Row) data).getFields().stream().map(TestTypeUtils::inferTypeFromData).collect(Collectors.toList()));
+          d.getFieldNames(),
+          d.getFields().stream().map(TestTypeUtils::inferTypeFromData).collect(Collectors.toList()));
     } else if (data instanceof FunctionCall) {
       return TestTypeFactory.UNKNOWN_TEST_TYPE;
     } else {


### PR DESCRIPTION
Why: hiveTest for an internal MP fails like this:
```
Gradle suite > Gradle test > com.linkedin.YYYYYYYYYY.XXXXXX.ZZZZZZZ FAILED
    java.lang.AssertionError: UDF output does not match expected [{"field0":"class","field1":"exampleString"}] but found [{"classname":"class","data":"exampleString"}]
        at org.testng.Assert.fail(Assert.java:94)
        at org.testng.Assert.failNotEquals(Assert.java:494)
        at org.testng.Assert.assertEquals(Assert.java:123)
        at com.linkedin.transport.test.hive.HiveTester.assertFunctionCall(HiveTester.java:132)
        at com.linkedin.transport.test.spi.SqlStdTester.check(SqlStdTester.java:31)
        at com.linkedin.transport.test.spi.StdTester.check(StdTester.java:38)
        at com.linkedin.YYYYYYYYYY.XXXXXX.ZZZZZZZ(PPPPPPPPPP.java:24)
```

in this case, we couldn't match struct's key names because we fall back
to field0 when fieldnames aren't defined

Since modifying constructor would require a major version bump, I think
a chaining method would be good enough here

Test Plan: Tried to reproduce the test case my customer ran in one of
the examples. The example passed after my commit's is equals method was
implemented.