### PR TITLE
Support conversion of String type to Utf8 in AvroWrapper

### DIFF
--- a/transportable-udfs-avro/src/main/java/com/linkedin/transport/avro/AvroWrapper.java
+++ b/transportable-udfs-avro/src/main/java/com/linkedin/transport/avro/AvroWrapper.java
@@ -43,24 +43,12 @@ public class AvroWrapper {
 
   public static StdData createStdData(Object avroData, Schema avroSchema) {
     switch (avroSchema.getType()) {
-      case INT: {
-        if (!(avroData instanceof Integer)) {
-          throw new IllegalArgumentException("Unsupported type for Avro integer: " + avroData.getClass());
-        }
+      case INT:
         return new AvroInteger((Integer) avroData);
-      }
-      case LONG: {
-        if (!(avroData instanceof Long)) {
-          throw new IllegalArgumentException("Unsupported type for Avro long: " + avroData.getClass());
-        }
+      case LONG:
         return new AvroLong((Long) avroData);
-      }
-      case BOOLEAN: {
-        if (!(avroData instanceof Boolean)) {
-          throw new IllegalArgumentException("Unsupported type for Avro boolean: " + avroData.getClass());
-        }
+      case BOOLEAN:
         return new AvroBoolean((Boolean) avroData);
-      }
       case STRING: {
         if (avroData instanceof Utf8) {
           return new AvroString((Utf8) avroData);
@@ -69,42 +57,18 @@ public class AvroWrapper {
         }
         throw new IllegalArgumentException("Unsupported type for Avro string: " + avroData.getClass());
       }
-      case FLOAT: {
-        if (!(avroData instanceof Float)) {
-          throw new IllegalArgumentException("Unsupported type for Avro float: " + avroData.getClass());
-        }
+      case FLOAT:
         return new AvroFloat((Float) avroData);
-      }
-      case DOUBLE: {
-        if (!(avroData instanceof Double)) {
-          throw new IllegalArgumentException("Unsupported type for Avro double: " + avroData.getClass());
-        }
+      case DOUBLE:
         return new AvroDouble((Double) avroData);
-      }
-      case BYTES: {
-        if (!(avroData instanceof ByteBuffer)) {
-          throw new IllegalArgumentException("Unsupported type for Avro bytes: " + avroData.getClass());
-        }
+      case BYTES:
         return new AvroBinary((ByteBuffer) avroData);
-      }
-      case ARRAY: {
-        if (!(avroData instanceof GenericArray)) {
-          throw new IllegalArgumentException("Unsupported type for Avro array: " + avroData.getClass());
-        }
+      case ARRAY:
         return new AvroArray((GenericArray<Object>) avroData, avroSchema);
-      }
-      case MAP: {
-        if (!(avroData instanceof Map)) {
-          throw new IllegalArgumentException("Unsupported type for Avro map: " + avroData.getClass());
-        }
+      case MAP:
         return new AvroMap((Map<Object, Object>) avroData, avroSchema);
-      }
-      case RECORD: {
-        if (!(avroData instanceof GenericRecord)) {
-          throw new IllegalArgumentException("Unsupported type for Avro record: " + avroData.getClass());
-        }
+      case RECORD:
         return new AvroStruct((GenericRecord) avroData, avroSchema);
-      }
       case UNION: {
         Schema nonNullableType = getNonNullComponent(avroSchema);
         if (avroData == null) {

--- a/transportable-udfs-avro/src/main/java/com/linkedin/transport/avro/AvroWrapper.java
+++ b/transportable-udfs-avro/src/main/java/com/linkedin/transport/avro/AvroWrapper.java
@@ -43,32 +43,69 @@ public class AvroWrapper {
 
   public static StdData createStdData(Object avroData, Schema avroSchema) {
     switch (avroSchema.getType()) {
-      case INT:
+      case INT: {
+        if (!(avroData instanceof Integer)) {
+          throw new IllegalArgumentException("Unsupported type for Avro integer: " + avroData.getClass());
+        }
         return new AvroInteger((Integer) avroData);
-      case LONG:
+      }
+      case LONG: {
+        if (!(avroData instanceof Long)) {
+          throw new IllegalArgumentException("Unsupported type for Avro long: " + avroData.getClass());
+        }
         return new AvroLong((Long) avroData);
-      case BOOLEAN:
+      }
+      case BOOLEAN: {
+        if (!(avroData instanceof Boolean)) {
+          throw new IllegalArgumentException("Unsupported type for Avro boolean: " + avroData.getClass());
+        }
         return new AvroBoolean((Boolean) avroData);
+      }
       case STRING: {
         if (avroData instanceof Utf8) {
           return new AvroString((Utf8) avroData);
         } else if (avroData instanceof String) {
           return new AvroString(new Utf8((String) avroData));
         }
+        throw new IllegalArgumentException("Unsupported type for Avro string: " + avroData.getClass());
       }
-      case FLOAT:
+      case FLOAT: {
+        if (!(avroData instanceof Float)) {
+          throw new IllegalArgumentException("Unsupported type for Avro float: " + avroData.getClass());
+        }
         return new AvroFloat((Float) avroData);
-      case DOUBLE:
+      }
+      case DOUBLE: {
+        if (!(avroData instanceof Double)) {
+          throw new IllegalArgumentException("Unsupported type for Avro double: " + avroData.getClass());
+        }
         return new AvroDouble((Double) avroData);
-      case BYTES:
+      }
+      case BYTES: {
+        if (!(avroData instanceof ByteBuffer)) {
+          throw new IllegalArgumentException("Unsupported type for Avro bytes: " + avroData.getClass());
+        }
         return new AvroBinary((ByteBuffer) avroData);
-      case ARRAY:
+      }
+      case ARRAY: {
+        if (!(avroData instanceof GenericArray)) {
+          throw new IllegalArgumentException("Unsupported type for Avro array: " + avroData.getClass());
+        }
         return new AvroArray((GenericArray<Object>) avroData, avroSchema);
-      case MAP:
+      }
+      case MAP: {
+        if (!(avroData instanceof Map)) {
+          throw new IllegalArgumentException("Unsupported type for Avro map: " + avroData.getClass());
+        }
         return new AvroMap((Map<Object, Object>) avroData, avroSchema);
-      case RECORD:
+      }
+      case RECORD: {
+        if (!(avroData instanceof GenericRecord)) {
+          throw new IllegalArgumentException("Unsupported type for Avro record: " + avroData.getClass());
+        }
         return new AvroStruct((GenericRecord) avroData, avroSchema);
-      case UNION:{
+      }
+      case UNION: {
         Schema nonNullableType = getNonNullComponent(avroSchema);
         if (avroData == null) {
           return null;

--- a/transportable-udfs-avro/src/main/java/com/linkedin/transport/avro/AvroWrapper.java
+++ b/transportable-udfs-avro/src/main/java/com/linkedin/transport/avro/AvroWrapper.java
@@ -49,8 +49,13 @@ public class AvroWrapper {
         return new AvroLong((Long) avroData);
       case BOOLEAN:
         return new AvroBoolean((Boolean) avroData);
-      case STRING:
-        return new AvroString((Utf8) avroData);
+      case STRING: {
+        if (avroData instanceof Utf8) {
+          return new AvroString((Utf8) avroData);
+        } else if (avroData instanceof String) {
+          return new AvroString(new Utf8((String) avroData));
+        }
+      }
       case FLOAT:
         return new AvroFloat((Float) avroData);
       case DOUBLE:

--- a/transportable-udfs-avro/src/test/java/com/linkedin/transport/avro/TestAvroWrapper.java
+++ b/transportable-udfs-avro/src/test/java/com/linkedin/transport/avro/TestAvroWrapper.java
@@ -99,12 +99,8 @@ public class TestAvroWrapper {
   }
 
   @Test
-  public void testStringTypeUtf8() {
-    testSimpleType("string", AvroStringType.class, new Utf8("foo"), AvroString.class);
-  }
-
-  @Test
   public void testStringType() {
+    testSimpleType("string", AvroStringType.class, new Utf8("foo"), AvroString.class);
     testSimpleType("string", AvroStringType.class, "foo", AvroString.class);
   }
 

--- a/transportable-udfs-avro/src/test/java/com/linkedin/transport/avro/TestAvroWrapper.java
+++ b/transportable-udfs-avro/src/test/java/com/linkedin/transport/avro/TestAvroWrapper.java
@@ -65,7 +65,12 @@ public class TestAvroWrapper {
     StdData stdData = AvroWrapper.createStdData(testData, avroSchema);
     assertNotNull(stdData);
     assertTrue(expectedDataClass.isAssignableFrom(stdData.getClass()));
-    assertEquals(testData, ((PlatformData) stdData).getUnderlyingData());
+    if ("string".equals(typeName)) {
+      // Use String values for equality assertion as we support both Utf8 and String input types
+      assertEquals(testData.toString(), ((PlatformData) stdData).getUnderlyingData().toString());
+    } else {
+      assertEquals(testData, ((PlatformData) stdData).getUnderlyingData());
+    }
   }
 
   @Test
@@ -94,8 +99,13 @@ public class TestAvroWrapper {
   }
 
   @Test
-  public void testStringType() {
+  public void testStringTypeUtf8() {
     testSimpleType("string", AvroStringType.class, new Utf8("foo"), AvroString.class);
+  }
+
+  @Test
+  public void testStringType() {
+    testSimpleType("string", AvroStringType.class, "foo", AvroString.class);
   }
 
   @Test


### PR DESCRIPTION
When reading Avro, objects of type String  may be passed in. Since Transport uses Utf8 types for AvroString, this can lead to incompatibility issues.