### PR TITLE
Upgrade to gradle 6.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ for each engine. For example, in Hive, you add the jar to the classpath using th
  and register the UDF using `CREATE FUNCTION` statement.
 In Presto, the jar is deployed to the `plugin` directory. However, a small patch is required for the Presto
 engine to recognize the jar as a plugin, since the generated Presto UDFs implement the `SqlScalarFunction` API, 
-which is currently not part of Presto's SPI architecture. You can find the patch [here](transportable-udfs-documentation/transport-udfs-presto.patch) and apply it
+which is currently not part of Presto's SPI architecture. You can find the patch [here](docs/transport-udfs-presto.patch) and apply it
  before deploying your UDFs jar to the Presto engine.
  
 ## Contributing

--- a/build.gradle
+++ b/build.gradle
@@ -74,8 +74,11 @@ subprojects {
     }
 
     checkstyle {
-      configFile = file("${rootDir}/gradle/checkstyle/checkstyle.xml")
-      configProperties = ['config_loc' : "${rootDir}/gradle/checkstyle/"]
+      configFile = rootProject.file('gradle/checkstyle/checkstyle.xml')
+      configProperties = [
+          'configDir': rootProject.file('gradle/checkstyle'),
+          'baseDir': rootDir
+      ]
       toolVersion '8.23'
     }
   }

--- a/gradle/checkstyle/checkstyle.xml
+++ b/gradle/checkstyle/checkstyle.xml
@@ -191,7 +191,8 @@ LinkedIn Java style.
        Before uncommenting this please read the "Suppression File" section of http://go/checkstyle
        to prevent error events in IntelliJ IDEA. -->
   <module name="SuppressionFilter">
-    <property name="file" value="${config_loc}/suppressions.xml"/>
+    <property name="file" value="${configDir}/suppressions.xml"/>
+    <property name="optional" value="false"/>
   </module>
 
   <!-- Allow Checkstyle warnings to be suppressed using block comments -->

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/transportable-udfs-examples/build.gradle
+++ b/transportable-udfs-examples/build.gradle
@@ -62,8 +62,11 @@ subprojects {
     }
 
     checkstyle {
-      configFile = file("${rootDir}/../gradle/checkstyle/checkstyle.xml")
-      configProperties = ['config_loc' : "${rootDir}/../gradle/checkstyle/"]
+      configFile = rootProject.file('../gradle/checkstyle/checkstyle.xml')
+      configProperties = [
+          'configDir': rootProject.file('../gradle/checkstyle'),
+          'baseDir': "${rootDir}/.."
+      ]
       toolVersion '8.23'
     }
   }

--- a/transportable-udfs-examples/gradle/wrapper/gradle-wrapper.properties
+++ b/transportable-udfs-examples/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.0-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip


### PR DESCRIPTION
Motivation:
As part of the Trino upgrade/migration (#66), we need to isolate and build transport modules for different engines with different jdk versions. For instance, Spark & Hive needs to build with jdk8 and Trino has a build requirement on jdk11. By moving to gradle 6.7, we can leverage [toolchains](https://docs.gradle.org/current/userguide/toolchains.html) which will help in easier configuration of different aspects of the build.