### PR TITLE
Bump Avro dependency to 1.10.2 (from 1.7.7).

### DIFF
--- a/transportable-udfs-avro/build.gradle
+++ b/transportable-udfs-avro/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'java'
 dependencies {
   compile project(':transportable-udfs-api')
   compile project(':transportable-udfs-type-system')
-  compile('org.apache.avro:avro:1.7.7')
+  compile('org.apache.avro:avro:1.10.2')
   testCompile project(path: ':transportable-udfs-type-system', configuration: 'tests')
 }
 


### PR DESCRIPTION
There doesn't seem to be any impact to the code. gradle build passes.