### PR TITLE
Update ci.yml java version to 8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           distribution: 'adopt'
-          java-version: '11'
+          java-version: '8'
 
       - name: 3. Perform build
         run: ./gradlew build


### PR DESCRIPTION
The previous github action flow failed in compilation because it's using jdk 11 to compile, which is wrong, we should use jdk 8 as default, only the trino modules will be using jdk11, but that is taken care of by the module specific gradle setting:

```
toolchain {
        languageVersion = JavaLanguageVersion.of(11)
    }
}
```
in #69 .