### PR TITLE
Fix org.pentaho:pentaho-aggdesigner-algorithm sunset problem

### DIFF
--- a/transportable-udfs-hive/build.gradle
+++ b/transportable-udfs-hive/build.gradle
@@ -7,10 +7,12 @@ dependencies {
   compile('org.apache.hadoop:hadoop-common:2.7.4')
   compileOnly('org.apache.hive:hive-exec:1.2.2') {
     exclude group: 'org.apache.avro'
+    exclude group: 'org.apache.calcite'
   }
   testCompile project(path: ':transportable-udfs-type-system', configuration: 'tests')
   testCompile('org.apache.hive:hive-exec:1.2.2') {
     exclude group: 'org.apache.avro'
+    exclude group: 'org.apache.calcite'
   }
 }
 

--- a/transportable-udfs-plugin/src/main/java/com/linkedin/transport/plugin/Defaults.java
+++ b/transportable-udfs-plugin/src/main/java/com/linkedin/transport/plugin/Defaults.java
@@ -46,15 +46,15 @@ class Defaults {
   private static final String getVersion(final String platform) {
     return DEFAULT_VERSIONS.getProperty(platform + "-version");
   }
-  private static final String PLATFORM_HIVE = "hive";
-  private static final String PLATFORM_SPARK = "spark";
-  private static final String PLATFORM_TRINO = "trino";
+  private static final String HIVE = "hive";
+  private static final String SPARK = "spark";
+  private static final String TRINO = "trino";
 
   private static final String TRANSPORT_VERSION = getVersion("transport");
   private static final String SCALA_VERSION = getVersion("scala");
-  private static final String HIVE_VERSION = getVersion(PLATFORM_HIVE);
-  private static final String SPARK_VERSION = getVersion(PLATFORM_SPARK);
-  private static final String TRINO_VERSION = getVersion(PLATFORM_TRINO);
+  private static final String HIVE_VERSION = getVersion(HIVE);
+  private static final String SPARK_VERSION = getVersion(SPARK);
+  private static final String TRINO_VERSION = getVersion(TRINO);
 
   static final List<DependencyConfiguration> MAIN_SOURCE_SET_DEPENDENCY_CONFIGURATIONS = ImmutableList.of(
       DependencyConfiguration.builder(IMPLEMENTATION, "com.linkedin.transport:transportable-udfs-api", TRANSPORT_VERSION).build(),
@@ -70,8 +70,7 @@ class Defaults {
   );
 
   static final List<Platform> DEFAULT_PLATFORMS = ImmutableList.of(
-      new Platform(
-          PLATFORM_TRINO,
+      new Platform(TRINO,
           Language.JAVA,
           TrinoWrapperGenerator.class,
           JavaLanguageVersion.of(11),
@@ -86,8 +85,7 @@ class Defaults {
               DependencyConfiguration.builder(RUNTIME_ONLY, "io.trino:trino-main", TRINO_VERSION).classifier("tests").build()
           ),
           ImmutableList.of(new ThinJarPackaging(), new DistributionPackaging())),
-      new Platform(
-          PLATFORM_HIVE,
+      new Platform(HIVE,
           Language.JAVA,
           HiveWrapperGenerator.class,
           JavaLanguageVersion.of(8),
@@ -99,8 +97,7 @@ class Defaults {
               DependencyConfiguration.builder(RUNTIME_ONLY, "com.linkedin.transport:transportable-udfs-test-hive", TRANSPORT_VERSION).build()
           ),
           ImmutableList.of(new ShadedJarPackaging(ImmutableList.of("org.apache.hadoop", "org.apache.hive"), null))),
-      new Platform(
-          PLATFORM_SPARK,
+      new Platform(SPARK,
           Language.SCALA,
           SparkWrapperGenerator.class,
           JavaLanguageVersion.of(8),

--- a/transportable-udfs-plugin/src/main/java/com/linkedin/transport/plugin/Defaults.java
+++ b/transportable-udfs-plugin/src/main/java/com/linkedin/transport/plugin/Defaults.java
@@ -43,82 +43,77 @@ class Defaults {
     }
   }
 
+  private static final String getVersion(final String platform) {
+    return DEFAULT_VERSIONS.getProperty(platform + "-version");
+  }
+  private static final String PLATFORM_HIVE = "hive";
+  private static final String PLATFORM_SPARK = "spark";
+  private static final String PLATFORM_TRINO = "trino";
+
+  private static final String TRANSPORT_VERSION = getVersion("transport");
+  private static final String SCALA_VERSION = getVersion("scala");
+  private static final String HIVE_VERSION = getVersion(PLATFORM_HIVE);
+  private static final String SPARK_VERSION = getVersion(PLATFORM_SPARK);
+  private static final String TRINO_VERSION = getVersion(PLATFORM_TRINO);
+
   static final List<DependencyConfiguration> MAIN_SOURCE_SET_DEPENDENCY_CONFIGURATIONS = ImmutableList.of(
-      getDependencyConfiguration(IMPLEMENTATION, "com.linkedin.transport:transportable-udfs-api", "transport"),
-      getDependencyConfiguration(ANNOTATION_PROCESSOR, "com.linkedin.transport:transportable-udfs-annotation-processor",
-          "transport"),
+      DependencyConfiguration.builder(IMPLEMENTATION, "com.linkedin.transport:transportable-udfs-api", TRANSPORT_VERSION).build(),
+      DependencyConfiguration.builder(ANNOTATION_PROCESSOR, "com.linkedin.transport:transportable-udfs-annotation-processor", TRANSPORT_VERSION).build(),
       // the idea plugin needs a scala-library on the classpath when the scala plugin is applied even when there are no
       // scala sources
-      getDependencyConfiguration(COMPILE_ONLY, "org.scala-lang:scala-library", "scala")
+      DependencyConfiguration.builder(COMPILE_ONLY, "org.scala-lang:scala-library", SCALA_VERSION).build()
   );
 
   static final List<DependencyConfiguration> TEST_SOURCE_SET_DEPENDENCY_CONFIGURATIONS = ImmutableList.of(
-      getDependencyConfiguration(IMPLEMENTATION, "com.linkedin.transport:transportable-udfs-test-api", "transport"),
-      getDependencyConfiguration(RUNTIME_ONLY, "com.linkedin.transport:transportable-udfs-test-generic", "transport")
+      DependencyConfiguration.builder(IMPLEMENTATION, "com.linkedin.transport:transportable-udfs-test-api", TRANSPORT_VERSION).build(),
+      DependencyConfiguration.builder(RUNTIME_ONLY, "com.linkedin.transport:transportable-udfs-test-generic", TRANSPORT_VERSION).build()
   );
 
   static final List<Platform> DEFAULT_PLATFORMS = ImmutableList.of(
       new Platform(
-          "trino",
+          PLATFORM_TRINO,
           Language.JAVA,
           TrinoWrapperGenerator.class,
           JavaLanguageVersion.of(11),
           ImmutableList.of(
-              getDependencyConfiguration(IMPLEMENTATION, "com.linkedin.transport:transportable-udfs-trino",
-                  "transport"),
-              getDependencyConfiguration(COMPILE_ONLY, "io.trino:trino-main", "trino")
+              DependencyConfiguration.builder(IMPLEMENTATION, "com.linkedin.transport:transportable-udfs-trino", TRANSPORT_VERSION).build(),
+              DependencyConfiguration.builder(COMPILE_ONLY, "io.trino:trino-main", TRINO_VERSION).build()
           ),
           ImmutableList.of(
-              getDependencyConfiguration(RUNTIME_ONLY, "com.linkedin.transport:transportable-udfs-test-trino",
-                  "transport"),
+              DependencyConfiguration.builder(RUNTIME_ONLY, "com.linkedin.transport:transportable-udfs-test-trino", TRANSPORT_VERSION).build(),
               // trino-main:tests is a transitive dependency of transportable-udfs-test-trino, but some POM -> IVY
               // converters drop dependencies with classifiers, so we apply this dependency explicitly
-              getDependencyConfiguration(RUNTIME_ONLY, "io.trino:trino-main", "trino", "tests")
+              DependencyConfiguration.builder(RUNTIME_ONLY, "io.trino:trino-main", TRINO_VERSION).classifier("tests").build()
           ),
           ImmutableList.of(new ThinJarPackaging(), new DistributionPackaging())),
       new Platform(
-          "hive",
+          PLATFORM_HIVE,
           Language.JAVA,
           HiveWrapperGenerator.class,
           JavaLanguageVersion.of(8),
           ImmutableList.of(
-              getDependencyConfiguration(IMPLEMENTATION, "com.linkedin.transport:transportable-udfs-hive", "transport"),
-              getDependencyConfiguration(COMPILE_ONLY, "org.apache.hive:hive-exec", "hive")
+              DependencyConfiguration.builder(IMPLEMENTATION, "com.linkedin.transport:transportable-udfs-hive", TRANSPORT_VERSION).build(),
+              DependencyConfiguration.builder(COMPILE_ONLY, "org.apache.hive:hive-exec", HIVE_VERSION).exclude("org.apache.calcite").build()
           ),
           ImmutableList.of(
-              getDependencyConfiguration(RUNTIME_ONLY, "com.linkedin.transport:transportable-udfs-test-hive",
-                  "transport")
+              DependencyConfiguration.builder(RUNTIME_ONLY, "com.linkedin.transport:transportable-udfs-test-hive", TRANSPORT_VERSION).build()
           ),
           ImmutableList.of(new ShadedJarPackaging(ImmutableList.of("org.apache.hadoop", "org.apache.hive"), null))),
       new Platform(
-          "spark",
+          PLATFORM_SPARK,
           Language.SCALA,
           SparkWrapperGenerator.class,
           JavaLanguageVersion.of(8),
           ImmutableList.of(
-              getDependencyConfiguration(IMPLEMENTATION, "com.linkedin.transport:transportable-udfs-spark",
-                  "transport"),
-              getDependencyConfiguration(COMPILE_ONLY, "org.apache.spark:spark-sql_2.11", "spark")
+              DependencyConfiguration.builder(IMPLEMENTATION, "com.linkedin.transport:transportable-udfs-spark", TRANSPORT_VERSION).build(),
+              DependencyConfiguration.builder(COMPILE_ONLY, "org.apache.spark:spark-sql_2.11", SPARK_VERSION).build()
           ),
           ImmutableList.of(
-              getDependencyConfiguration(RUNTIME_ONLY, "com.linkedin.transport:transportable-udfs-test-spark",
-                  "transport")
+              DependencyConfiguration.builder(RUNTIME_ONLY, "com.linkedin.transport:transportable-udfs-test-spark", TRANSPORT_VERSION).build()
           ),
           ImmutableList.of(new ShadedJarPackaging(
               ImmutableList.of("org.apache.hadoop", "org.apache.spark"),
               ImmutableList.of("com.linkedin.transport.spark.**")))
       )
   );
-
-  private static DependencyConfiguration getDependencyConfiguration(ConfigurationType configurationType,
-      String module, String platform) {
-    return getDependencyConfiguration(configurationType, module, platform, null);
-  }
-
-  private static DependencyConfiguration getDependencyConfiguration(ConfigurationType configurationType,
-      String module, String platform, String classifier) {
-    return new DependencyConfiguration(configurationType, module
-        + ":" + DEFAULT_VERSIONS.getProperty(platform + "-version")
-        + (classifier != null ? (":" + classifier) : ""));
-  }
 }

--- a/transportable-udfs-plugin/src/main/java/com/linkedin/transport/plugin/DependencyConfiguration.java
+++ b/transportable-udfs-plugin/src/main/java/com/linkedin/transport/plugin/DependencyConfiguration.java
@@ -25,14 +25,14 @@ public class DependencyConfiguration {
   private final String _module;
   private final String _version;
   private final String _classifier;
-  private final Set<Map<String, String>> _excludedPackageModules;
+  private final Set<Map<String, String>> _excludedProperties;
 
   private DependencyConfiguration(Builder builder) {
     this._configurationType = builder._configurationType;
     this._module = builder._module;
     this._version = builder._version;
     this._classifier = builder._classifier;
-    this._excludedPackageModules = builder._excludedPackageModules;
+    this._excludedProperties = builder._excludedProperties;
   }
 
   public ConfigurationType getConfigurationType() {
@@ -43,8 +43,8 @@ public class DependencyConfiguration {
     return _module + ":" + _version + Optional.ofNullable(_classifier).map(v -> ":" + v).orElse("");
   }
 
-  public Set<Map<String, String>> getExcludedPackageModules() {
-    return _excludedPackageModules;
+  public Set<Map<String, String>> getExcludedProperties() {
+    return _excludedProperties;
   }
 
   public static Builder builder(final ConfigurationType configurationType, final String module, final String version) {
@@ -56,7 +56,7 @@ public class DependencyConfiguration {
     private final String _module;
     private String _version;
     private String _classifier;
-    private Set<Map<String, String>> _excludedPackageModules;
+    private Set<Map<String, String>> _excludedProperties;
 
     public Builder(final ConfigurationType configurationType, final String module, final String version) {
       Objects.requireNonNull(configurationType);
@@ -79,10 +79,10 @@ public class DependencyConfiguration {
 
     public Builder exclude(final String group, final String module) {
       Objects.requireNonNull(group);
-      if (_excludedPackageModules == null) {
-        _excludedPackageModules = new HashSet<>();
+      if (_excludedProperties == null) {
+        _excludedProperties = new HashSet<>();
       }
-      _excludedPackageModules.add((module == null)
+      _excludedProperties.add((module == null)
           ? ImmutableMap.of(GROUP_KEY, group)
           : ImmutableMap.of(GROUP_KEY, group, MODULE_KEY, module)
       );

--- a/transportable-udfs-plugin/src/main/java/com/linkedin/transport/plugin/DependencyConfiguration.java
+++ b/transportable-udfs-plugin/src/main/java/com/linkedin/transport/plugin/DependencyConfiguration.java
@@ -5,17 +5,34 @@
  */
 package com.linkedin.transport.plugin;
 
+import com.google.common.collect.ImmutableMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+
 /**
  * Represents a dependency to be applied to a certain sourceset configuration (e.g. implementation, compileOnly, etc.)
  * In the future can expand to incorporate exclude rules, dependency substitutions, etc.
  */
 public class DependencyConfiguration {
-  private ConfigurationType _configurationType;
-  private String _dependencyString;
+  private static final String GROUP_KEY = "group";
+  private static final String MODULE_KEY = "module";
 
-  public DependencyConfiguration(ConfigurationType configurationType, String dependencyString) {
-    _configurationType = configurationType;
-    _dependencyString = dependencyString;
+  private final ConfigurationType _configurationType;
+  private final String _module;
+  private final String _version;
+  private final String _classifier;
+  private final Set<Map<String, String>> _excludedPackageModules;
+
+  private DependencyConfiguration(Builder builder) {
+    this._configurationType = builder._configurationType;
+    this._module = builder._module;
+    this._version = builder._version;
+    this._classifier = builder._classifier;
+    this._excludedPackageModules = builder._excludedPackageModules;
   }
 
   public ConfigurationType getConfigurationType() {
@@ -23,6 +40,57 @@ public class DependencyConfiguration {
   }
 
   public String getDependencyString() {
-    return _dependencyString;
+    return _module + ":" + _version + Optional.ofNullable(_classifier).map(v -> ":" + v).orElse("");
+  }
+
+  public Set<Map<String, String>> getExcludedPackageModules() {
+    return _excludedPackageModules;
+  }
+
+  public static Builder builder(final ConfigurationType configurationType, final String module, final String version) {
+    return new Builder(configurationType, module, version);
+  }
+
+  public static class Builder {
+    private final ConfigurationType _configurationType;
+    private final String _module;
+    private String _version;
+    private String _classifier;
+    private Set<Map<String, String>> _excludedPackageModules;
+
+    public Builder(final ConfigurationType configurationType, final String module, final String version) {
+      Objects.requireNonNull(configurationType);
+      Objects.requireNonNull(module);
+      Objects.requireNonNull(version);
+      this._configurationType = configurationType;
+      this._module = module;
+      this._version = version;
+    }
+
+    public Builder classifier(final String classifier) {
+      Objects.requireNonNull(classifier);
+      _classifier = classifier;
+      return this;
+    }
+
+    public Builder exclude(final String group) {
+      return exclude(group, null);
+    }
+
+    public Builder exclude(final String group, final String module) {
+      Objects.requireNonNull(group);
+      if (_excludedPackageModules == null) {
+        _excludedPackageModules = new HashSet<>();
+      }
+      _excludedPackageModules.add((module == null)
+          ? ImmutableMap.of(GROUP_KEY, group)
+          : ImmutableMap.of(GROUP_KEY, group, MODULE_KEY, module)
+      );
+      return this;
+    }
+
+    public DependencyConfiguration build() {
+      return new DependencyConfiguration(this);
+    }
   }
 }

--- a/transportable-udfs-plugin/src/main/java/com/linkedin/transport/plugin/SourceSetUtils.java
+++ b/transportable-udfs-plugin/src/main/java/com/linkedin/transport/plugin/SourceSetUtils.java
@@ -115,7 +115,7 @@ public class SourceSetUtils {
     addDependencyToConfiguration(
         getConfigurationForSourceSet(project, sourceSet, dependencyConfiguration.getConfigurationType()),
         createDependency(project, dependencyConfiguration.getDependencyString()),
-        dependencyConfiguration.getExcludedPackageModules()
+        dependencyConfiguration.getExcludedProperties()
     );
   }
 

--- a/transportable-udfs-plugin/src/main/java/com/linkedin/transport/plugin/SourceSetUtils.java
+++ b/transportable-udfs-plugin/src/main/java/com/linkedin/transport/plugin/SourceSetUtils.java
@@ -6,9 +6,15 @@
 package com.linkedin.transport.plugin;
 
 import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nullable;
 import org.codehaus.groovy.runtime.InvokerHelper;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.artifacts.ModuleDependency;
+import org.gradle.api.artifacts.dsl.DependencyHandler;
 import org.gradle.api.file.SourceDirectorySet;
 import org.gradle.api.plugins.Convention;
 import org.gradle.api.tasks.ScalaSourceSet;
@@ -75,7 +81,30 @@ public class SourceSetUtils {
    * Adds the provided dependency to the given {@link Configuration}
    */
   static void addDependencyToConfiguration(Project project, Configuration configuration, Object dependency) {
-    configuration.withDependencies(dependencySet -> dependencySet.add(project.getDependencies().create(dependency)));
+    addDependencyToConfiguration(configuration, createDependency(project, dependency), null);
+  }
+
+  /**
+   * Adds the provided dependency {@link Dependency} to the given {@link Configuration},
+   * excluding the elements in the excludeProperties
+   */
+  static void addDependencyToConfiguration(final Configuration configuration, final Dependency dependency,
+      final @Nullable Set<Map<String, String>> excludeProperties) {
+    configuration.withDependencies(dependencySet -> {
+      if (excludeProperties != null) {
+        if (dependency instanceof ModuleDependency) {
+          excludeProperties.stream().forEach(((ModuleDependency) dependency)::exclude);
+        }
+      }
+      dependencySet.add(dependency);
+    });
+  }
+
+  /**
+   * Create {@link Dependency} by {@link Project}'s {@link DependencyHandler}
+   */
+  static Dependency createDependency(final Project project, Object dependency) {
+    return project.getDependencies().create(dependency);
   }
 
   /**
@@ -83,9 +112,11 @@ public class SourceSetUtils {
    */
   static void addDependencyConfigurationToSourceSet(Project project, SourceSet sourceSet,
       DependencyConfiguration dependencyConfiguration) {
-    addDependencyToConfiguration(project,
-        SourceSetUtils.getConfigurationForSourceSet(project, sourceSet, dependencyConfiguration.getConfigurationType()),
-        dependencyConfiguration.getDependencyString());
+    addDependencyToConfiguration(
+        getConfigurationForSourceSet(project, sourceSet, dependencyConfiguration.getConfigurationType()),
+        createDependency(project, dependencyConfiguration.getDependencyString()),
+        dependencyConfiguration.getExcludedPackageModules()
+    );
   }
 
   /**

--- a/transportable-udfs-test/transportable-udfs-test-hive/build.gradle
+++ b/transportable-udfs-test/transportable-udfs-test-hive/build.gradle
@@ -4,6 +4,13 @@ dependencies {
   compile project(':transportable-udfs-api')
   compile project(':transportable-udfs-hive')
   compile project(':transportable-udfs-test:transportable-udfs-test-api')
-  compile('org.apache.hive:hive-exec:1.2.2')
-  compile('org.apache.hive:hive-service:1.2.2')
+  compile ('org.apache.calcite:calcite-core:1.2.0-incubating') {
+    exclude group: 'org.pentaho', module: 'pentaho-aggdesigner-algorithm'
+  }
+  compile ('org.apache.hive:hive-exec:1.2.2') {
+    exclude group: 'org.apache.calcite'
+  }
+  compile ('org.apache.hive:hive-service:1.2.2') {
+    exclude group: 'org.apache.hive', module: 'hive-exec'
+  }
 }


### PR DESCRIPTION
org.pentaho:pentaho-aggdesigner-algorithm is official sunset by the author. The artifactory has been official removed from the maven repository. It is causing the build failure of Transport UDF.


* What went wrong:
Execution failed for task ':transportable-udfs-test:transportable-udfs-test-hive:compileJava'.
> Could not resolve all files for configuration ':transportable-udfs-test:transportable-udfs-test-hive:compileClasspath'.
   > Could not find org.pentaho:pentaho-aggdesigner-algorithm:5.1.5-jhyde.
     Searched in the following locations:
       - https://repo.maven.apache.org/maven2/org/pentaho/pentaho-aggdesigner-algorithm/5.1.5-jhyde/pentaho-aggdesigner-algorithm-5.1.5-jhyde.pom
       - https://jcenter.bintray.com/org/pentaho/pentaho-aggdesigner-algorithm/5.1.5-jhyde/pentaho-aggdesigner-algorithm-5.1.5-jhyde.pom
       - https://conjars.org/repo/org/pentaho/pentaho-aggdesigner-algorithm/5.1.5-jhyde/pentaho-aggdesigner-algorithm-5.1.5-jhyde.pom
     Required by:
         project :transportable-udfs-test:transportable-udfs-test-hive > org.apache.hive:hive-service:1.2.2 > org.apache.hive:hive-exec:1.2.2 > org.apache.calcite:calcite-core:1.2.0-incubating