### PR TITLE
Update ci.yml to also build the udf-examples folder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
 
       - name: 3. Perform build
         run: ./gradlew build
+        run: ./gradlew -p transportable-udfs-examples clean build -s
 
       - name: 4. Perform release
         # Release job, only for pushes to the main development branch


### PR DESCRIPTION
Currently the transportable-udfs-examples is not being built as part of pull requests. Adding this to CI to enable validations.