### PR TITLE
A solution to fix running multiple UDFs in Spark issue

### DIFF
--- a/transportable-udfs-plugin/src/main/java/com/linkedin/transport/plugin/Defaults.java
+++ b/transportable-udfs-plugin/src/main/java/com/linkedin/transport/plugin/Defaults.java
@@ -112,8 +112,12 @@ class Defaults {
           ),
           ImmutableList.of(new ShadedJarPackaging(
               ImmutableList.of("org.apache.hadoop", "org.apache.spark"),
-              ImmutableList.of("com.linkedin.transport.spark.**")))
-          ),
+              ImmutableList.of(
+                  "com.linkedin.transport.spark.stdUDFRegistration",
+                  "com.linkedin.transport.spark.SparkStdUDF"
+              )
+          ))
+      ),
       new Platform(SPARK_2_12,
           Language.SCALA,
           SparkWrapperGenerator.class,
@@ -127,7 +131,11 @@ class Defaults {
           ),
           ImmutableList.of(new ShadedJarPackaging(
               ImmutableList.of("org.apache.hadoop", "org.apache.spark"),
-              ImmutableList.of("com.linkedin.transport.spark.**")))
+              ImmutableList.of(
+                  "com.linkedin.transport.spark.stdUDFRegistration",
+                  "com.linkedin.transport.spark.SparkStdUDF"
+              )
+          ))
       )
   );
 }


### PR DESCRIPTION
A temporary solution to resolve the issue - two transport UDF cannot run in spark shell simultaneously.

The current solution may not be the best solution. The tradeoff is if multiple UDFs can be generated from multiple transport UDF versions

The client still can use the following patten to register the UDF function via Spark.

import com.linkedin.transport.example.spark.ExampleUDF
val exampleUDF = ExampleUDF.register("example_udf")

However, using the StdUDFRegistration.regsiter() Utils to register the UDF function will not be supported.

Notes:
com.linkedin.trasnport.spark.stdUDFRegistration & com.linkedin.transport.spark.SparkStdUDF CANNOT be shaded
due to the spark template is applied to generate the spark wrapper class.