### PR TITLE
Temporarily pause the `performRelease` stage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
           && github.repository == 'linkedin/transport'
           && !contains(toJSON(github.event.commits.*.message), '[skip release]')
 
-        run: ./gradlew githubRelease closeAndReleaseStagingRepository
+        run: ./gradlew clean
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
           SONATYPE_USER: ${{secrets.SONATYPE_USER}}


### PR DESCRIPTION
Let's keep the step trigged with faked ./gradlew clean action. It can help us to verify if the CI/CD works will or not right now. 