### PR TITLE
Transport-Spark: Ensure initialize is called before eval

### DIFF
--- a/transportable-udfs-spark_2.11/src/main/scala/com/linkedin/transport/spark/StdUdfWrapper.scala
+++ b/transportable-udfs-spark_2.11/src/main/scala/com/linkedin/transport/spark/StdUdfWrapper.scala
@@ -126,7 +126,7 @@ abstract class StdUdfWrapper(_expressions: Seq[Expression]) extends Expression
   // Suppressing magic number warming since the number match is required to cast it into the corresponding StdUDF
   // scalastyle:off magic.number
   override def eval(input: InternalRow): Any = { // scalastyle:ignore cyclomatic.complexity
-    // make sure the UDF has been initialized
+    // Make sure the UDF has been initialized
     if(!_initialized) {
       initialize()
     }

--- a/transportable-udfs-spark_2.11/src/main/scala/com/linkedin/transport/spark/StdUdfWrapper.scala
+++ b/transportable-udfs-spark_2.11/src/main/scala/com/linkedin/transport/spark/StdUdfWrapper.scala
@@ -126,6 +126,8 @@ abstract class StdUdfWrapper(_expressions: Seq[Expression]) extends Expression
   // Suppressing magic number warming since the number match is required to cast it into the corresponding StdUDF
   // scalastyle:off magic.number
   override def eval(input: InternalRow): Any = { // scalastyle:ignore cyclomatic.complexity
+    // access outputDataType to make sure it's been initialized
+    _outputDataType
     val wrappedArguments = checkNullsAndWrapArguments(input)
     // If wrappedArguments is null, it means there were non-nullable arguments whose value was evaluated to be null
     // So we do not call user's eval()


### PR DESCRIPTION
Previously, there's no contract that can let us make sure the `StdUdfWrapper` 's `initialize` method will always happen-before the `eval` method, rendering `NPE`s where the fields inside `initialize` not initialized when they are directly accessed in `eval`.

This change utilizes the `lazy val` feature of scala to makes sure the happens-before contract of `initialize` and `eval`. We also adds a contract to make `initialize` happens-before`checkInputDataTypes`, as `checkInputDataTypes` is also part spark's `Expression` contract.