### PR TITLE
Transport-spark: Only add files to sparkContext from driver

### DIFF
--- a/transportable-udfs-spark_2.11/src/main/scala/com/linkedin/transport/spark/StdUdfWrapper.scala
+++ b/transportable-udfs-spark_2.11/src/main/scala/com/linkedin/transport/spark/StdUdfWrapper.scala
@@ -13,7 +13,7 @@ import com.linkedin.transport.api.data.{PlatformData, StdData}
 import com.linkedin.transport.api.udf._
 import com.linkedin.transport.spark.typesystem.SparkTypeInference
 import com.linkedin.transport.utils.FileSystemUtils
-import org.apache.spark.SparkFiles
+import org.apache.spark.{SparkFiles, TaskContext}
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.Expression
@@ -47,7 +47,10 @@ abstract class StdUdfWrapper(_expressions: Seq[Expression]) extends Expression
     _stdUdf = _sparkTypeInference.getStdUdf
     _nullableArguments = _stdUdf.getAndCheckNullableArguments
     _stdUdf.init(_stdFactory)
-    getRequiredFiles()
+    // Only call this on driver
+    if (TaskContext.get == null) {
+      getRequiredFiles()
+    }
     _requiredFilesProcessed = false
     _initialized = true
   }


### PR DESCRIPTION
Before this patch, the `getRequiredFiles` will access `SparkSession` when it gets called on the spark executor, which will throw an exception:
```
java.lang.IllegalStateException: SparkSession should only be created and accessed on the driver
```

This patch adds a condition check to make sure the `getRequiredFiles` is only called on the driver, see ref: https://github.com/apache/spark/blob/93f646dd00ba8b3370bb904ba91862c407c62cc2/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala#L1154