### PR TITLE
Refactor getRequiredFiles to not add files in executor

### DIFF
--- a/transportable-udfs-spark_2.11/src/main/scala/com/linkedin/transport/spark/StdUdfWrapper.scala
+++ b/transportable-udfs-spark_2.11/src/main/scala/com/linkedin/transport/spark/StdUdfWrapper.scala
@@ -13,7 +13,7 @@ import com.linkedin.transport.api.data.{PlatformData, StdData}
 import com.linkedin.transport.api.udf._
 import com.linkedin.transport.spark.typesystem.SparkTypeInference
 import com.linkedin.transport.utils.FileSystemUtils
-import org.apache.spark.{SparkFiles, TaskContext}
+import org.apache.spark.SparkFiles
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.Expression
@@ -47,10 +47,7 @@ abstract class StdUdfWrapper(_expressions: Seq[Expression]) extends Expression
     _stdUdf = _sparkTypeInference.getStdUdf
     _nullableArguments = _stdUdf.getAndCheckNullableArguments
     _stdUdf.init(_stdFactory)
-    // Only call this on driver
-    if (TaskContext.get == null) {
-      getRequiredFiles()
-    }
+    getRequiredFiles()
     _requiredFilesProcessed = false
     _initialized = true
   }

--- a/transportable-udfs-spark_2.11/src/main/scala/com/linkedin/transport/spark/StdUdfWrapper.scala
+++ b/transportable-udfs-spark_2.11/src/main/scala/com/linkedin/transport/spark/StdUdfWrapper.scala
@@ -103,7 +103,7 @@ abstract class StdUdfWrapper(_expressions: Seq[Expression]) extends Expression
           }
         })
 
-        // Only adding files this on driver
+        // Only add files on the driver
         if (TaskContext.get == null) {
           val sparkContext = SparkSession.builder().getOrCreate().sparkContext
           // TODO: Currently does not support adding of files with same file name. E.g dirA/file.txt dirB/file.txt


### PR DESCRIPTION
The previous attempt #115 that tried to fix the issue seems not working, as it still throws NPE as mentioned in https://github.com/linkedin/transport/pull/115#discussion_r844370883.

This patch uses another approach: by refactoring the `getRequiredFiles` so that it initialize `_distributedCacheFiles` in both driver and executor, but only add those files when on driver.