### PR TITLE
Expand test framework to allow creating structs with field names.

### DIFF
--- a/transportable-udfs-test/transportable-udfs-test-api/src/main/java/com/linkedin/transport/test/AbstractStdUDFTest.java
+++ b/transportable-udfs-test/transportable-udfs-test-api/src/main/java/com/linkedin/transport/test/AbstractStdUDFTest.java
@@ -88,6 +88,10 @@ public abstract class AbstractStdUDFTest {
     return dataMap;
   }
 
+  protected static Row rowWithFieldNames(List<String> fieldNames, List<Object> args) {
+    return new Row(fieldNames, args);
+  }
+
   /**
    * Creates a row from the provided elements to pass to the test framework
    */

--- a/transportable-udfs-test/transportable-udfs-test-generic/src/main/java/com/linkedin/transport/test/generic/GenericQueryExecutor.java
+++ b/transportable-udfs-test/transportable-udfs-test-generic/src/main/java/com/linkedin/transport/test/generic/GenericQueryExecutor.java
@@ -116,12 +116,19 @@ class GenericQueryExecutor {
 
   private Pair<TestType, Object> resolveStruct(Row struct, List<TestType> fieldTypes) {
     List<TestType> resolvedFieldTypes = new ArrayList<>();
+    List<String> resolvedFieldNames = new ArrayList<>();
     List<Object> resolvedFields = new ArrayList<>();
     IntStream.range(0, fieldTypes.size()).forEach(idx -> {
       Pair<TestType, Object> resolvedField = resolveParameter(struct.getFields().get(idx), fieldTypes.get(idx));
+      if (struct.getFieldNames() != null) {
+        resolvedFieldNames.add(struct.getFieldNames().get(idx));
+      }
       resolvedFieldTypes.add(resolvedField.getLeft());
       resolvedFields.add(resolvedField.getRight());
     });
-    return Pair.of(TestTypeFactory.struct(resolvedFieldTypes), new Row(resolvedFields));
+    if (resolvedFieldNames.isEmpty()) {
+      return Pair.of(TestTypeFactory.struct(resolvedFieldTypes), new Row(resolvedFields));
+    }
+    return Pair.of(TestTypeFactory.struct(resolvedFieldNames, resolvedFieldTypes), new Row(resolvedFieldNames, resolvedFields));
   }
 }

--- a/transportable-udfs-test/transportable-udfs-test-spi/src/main/java/com/linkedin/transport/test/spi/Row.java
+++ b/transportable-udfs-test/transportable-udfs-test-spi/src/main/java/com/linkedin/transport/test/spi/Row.java
@@ -12,13 +12,23 @@ import java.util.Objects;
 public class Row {
 
   private final List<Object> _fields;
+  private List<String> _fieldNames;
 
   public Row(List<Object> fields) {
     _fields = fields;
   }
 
+  public Row(List<String> fieldNames, List<Object> fields) {
+    _fieldNames = fieldNames;
+    _fields = fields;
+  }
+
   public List<Object> getFields() {
     return _fields;
+  }
+
+  public List<String> getFieldNames() {
+    return _fieldNames;
   }
 
   @Override

--- a/transportable-udfs-test/transportable-udfs-test-spi/src/main/java/com/linkedin/transport/test/spi/types/TestTypeUtils.java
+++ b/transportable-udfs-test/transportable-udfs-test-spi/src/main/java/com/linkedin/transport/test/spi/types/TestTypeUtils.java
@@ -43,8 +43,14 @@ public class TestTypeUtils {
       return TestTypeFactory.map(inferCollectionTypeFromData(map.keySet(), "map keys"),
           inferCollectionTypeFromData(map.values(), "map values"));
     } else if (data instanceof Row) {
+      Row row = (Row) data;
+      if (row.getFieldNames() == null) {
+        return TestTypeFactory.struct(
+            row.getFields().stream().map(TestTypeUtils::inferTypeFromData).collect(Collectors.toList()));
+      }
       return TestTypeFactory.struct(
-          ((Row) data).getFields().stream().map(TestTypeUtils::inferTypeFromData).collect(Collectors.toList()));
+          row.getFieldNames(),
+          row.getFields().stream().map(TestTypeUtils::inferTypeFromData).collect(Collectors.toList()));
     } else if (data instanceof FunctionCall) {
       return TestTypeFactory.UNKNOWN_TEST_TYPE;
     } else {


### PR DESCRIPTION
The current transport UDF test framework does not let us create and return structs with field names. To write tests, we use `AbstractStdUDFTest`. This class makes a `FunctionCall` which internally uses `TestTypeUtils`. `TestTypeUtils` creates struct using `TestTypeFactory` and `Row`. Currently `Row` which is used to represent structs in the test framework doesn't have a constructor that lets us create structs with field names. On the other hand, `TestTypeFactory` allows us to do this. So this is a gap in the test framework. This also shows up when paramaters of a `FunctionCall` are resolved in `GenericQueryExecutor::resolveStruct` method. This PR is a step towards allowing test writers to pass a list of string fieldNames along with the data when they want to create structs with data and field names.