### PR TITLE
Upgrade Transport to compile Trino UDF with Java 17

### DIFF
--- a/transportable-udfs-examples/transportable-udfs-example-udfs/build.gradle
+++ b/transportable-udfs-examples/transportable-udfs-example-udfs/build.gradle
@@ -11,6 +11,7 @@ dependencies {
   // TODO: Reference all external dependencies from a single gradle file
   implementation('com.google.guava:guava:24.1-jre')
   implementation('org.apache.commons:commons-io:1.3.2')
+  testImplementation('io.airlift:aircompressor:0.21')
 }
 
 // As the tasks of trinoDistThinJar and trinoTrinJar are from Transport plugin which is built by Gradle 7.5.1,

--- a/transportable-udfs-plugin/build.gradle
+++ b/transportable-udfs-plugin/build.gradle
@@ -9,7 +9,7 @@ dependencies {
   implementation project(':transportable-udfs-codegen')
   implementation ('com.google.guava:guava:24.1-jre')
   implementation ('com.google.code.gson:gson:2.8.5')
-  implementation ('com.github.jengelman.gradle.plugins:shadow:5.0.0')
+  implementation ('com.github.jengelman.gradle.plugins:shadow:5.2.0')
   testImplementation('org.spockframework:spock-core:1.1-groovy-2.4') {
     exclude group: 'org.codehaus.groovy'
   }

--- a/transportable-udfs-plugin/src/main/java/com/linkedin/transport/plugin/Defaults.java
+++ b/transportable-udfs-plugin/src/main/java/com/linkedin/transport/plugin/Defaults.java
@@ -75,7 +75,7 @@ class Defaults {
       new Platform(TRINO,
           Language.JAVA,
           TrinoWrapperGenerator.class,
-          JavaLanguageVersion.of(11),
+          JavaLanguageVersion.of(17),
           ImmutableList.of(
               DependencyConfiguration.builder(IMPLEMENTATION, "com.linkedin.transport:transportable-udfs-trino", TRANSPORT_VERSION).build(),
               DependencyConfiguration.builder(COMPILE_ONLY, "io.trino:trino-main", TRINO_VERSION).build()

--- a/transportable-udfs-test/transportable-udfs-test-trino/build.gradle
+++ b/transportable-udfs-test/transportable-udfs-test-trino/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'java'
 
 java {
-  toolchain.languageVersion.set(JavaLanguageVersion.of(11))
+  toolchain.languageVersion.set(JavaLanguageVersion.of(17))
 }
 
 dependencies {

--- a/transportable-udfs-trino/build.gradle
+++ b/transportable-udfs-trino/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'java'
 
 java {
-  toolchain.languageVersion.set(JavaLanguageVersion.of(11))
+  toolchain.languageVersion.set(JavaLanguageVersion.of(17))
 }
 
 dependencies {


### PR DESCRIPTION
In order to make UDFs compiled by Transport can work with Trino v406, Transport needs to compile UDFs for Trino with Java 17.

Test
./gradlew clean build
cd transportable-udfs-example-udfs
./gradlew clean build

Also using javap -verbose classfile to confirm that the class files of UDFs for Trino are compiled with Java 17.