### PR TITLE
Update Transport with new API from Trino v406

### DIFF
--- a/defaultEnvironment.gradle
+++ b/defaultEnvironment.gradle
@@ -10,7 +10,7 @@ subprojects {
       url "https://conjars.org/repo"
     }
   }
-  project.ext.setProperty('trino-version', '352')
+  project.ext.setProperty('trino-version', '406')
   project.ext.setProperty('airlift-slice-version', '0.39')
   project.ext.setProperty('spark-group', 'org.apache.spark')
   project.ext.setProperty('spark2-version', '2.3.0')

--- a/transportable-udfs-examples/transportable-udfs-example-udfs/build.gradle
+++ b/transportable-udfs-examples/transportable-udfs-example-udfs/build.gradle
@@ -12,6 +12,7 @@ dependencies {
   implementation('com.google.guava:guava:24.1-jre')
   implementation('org.apache.commons:commons-io:1.3.2')
   testImplementation('io.airlift:aircompressor:0.21')
+  testImplementation('org.junit.jupiter:junit-jupiter-api:5.9.2')
 }
 
 // As the tasks of trinoDistThinJar and trinoTrinJar are from Transport plugin which is built by Gradle 7.5.1,

--- a/transportable-udfs-plugin/build.gradle
+++ b/transportable-udfs-plugin/build.gradle
@@ -19,7 +19,7 @@ def writeVersionInfo = { file ->
   ant.propertyfile(file: file) {
     entry(key: "transport-version", value: version)
     entry(key: "hive-version", value: '1.2.2')
-    entry(key: "trino-version", value: '352')
+    entry(key: "trino-version", value: '406')
     entry(key: "spark_2.11-version", value: '2.3.0')
     entry(key: "spark_2.12-version", value: '3.1.1')
     entry(key: "scala-version", value: '2.11.8')

--- a/transportable-udfs-test/transportable-udfs-test-spi/src/main/java/com/linkedin/transport/test/spi/SqlStdTester.java
+++ b/transportable-udfs-test/transportable-udfs-test-spi/src/main/java/com/linkedin/transport/test/spi/SqlStdTester.java
@@ -25,7 +25,9 @@ public interface SqlStdTester extends StdTester {
    * @param expectedOutputData  The expected output data from the function call
    * @param expectedOutputType  The expected output type from the function call
    */
-  void assertFunctionCall(String functionCallString, Object expectedOutputData, Object expectedOutputType);
+  default void assertFunctionCall(String functionCallString, Object expectedOutputData, Object expectedOutputType) {
+    throw new UnsupportedOperationException();
+  };
 
   default void check(TestCase testCase) {
     assertFunctionCall(getSqlFunctionCallGenerator().getSqlFunctionCallString(testCase.getFunctionCall()),

--- a/transportable-udfs-test/transportable-udfs-test-trino/build.gradle
+++ b/transportable-udfs-test/transportable-udfs-test-trino/build.gradle
@@ -20,4 +20,5 @@ dependencies {
   // The io.airlift.slice dependency below has to match its counterpart in trino-root's pom.xml file
   // If not specified, an older version is picked up transitively from another dependency
   implementation(group: 'io.airlift', name: 'slice', version: project.ext.'airlift-slice-version')
+  implementation(group: 'org.assertj', name: 'assertj-core', version: '3.24.2')
 }

--- a/transportable-udfs-test/transportable-udfs-test-trino/src/main/java/com/linkedin/transport/test/trino/TrinoTester.java
+++ b/transportable-udfs-test/transportable-udfs-test-trino/src/main/java/com/linkedin/transport/test/trino/TrinoTester.java
@@ -7,11 +7,16 @@ package com.linkedin.transport.test.trino;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import io.trino.metadata.BoundSignature;
+import com.linkedin.transport.test.spi.TestCase;
+import com.linkedin.transport.test.spi.types.TestType;
+import io.trino.FeaturesConfig;
+import io.trino.Session;
+import io.trino.SessionTestUtils;
+import io.trino.metadata.InternalFunctionBundle;
+import io.trino.metadata.SqlFunction;
+import io.trino.spi.function.BoundSignature;
 import io.trino.metadata.FunctionBinding;
-import io.trino.metadata.FunctionId;
-import io.trino.operator.scalar.AbstractTestFunctions;
-import io.trino.spi.type.Type;
+import io.trino.spi.function.FunctionId;
 import com.linkedin.transport.api.StdFactory;
 import com.linkedin.transport.api.udf.StdUDF;
 import com.linkedin.transport.api.udf.TopLevelStdUDF;
@@ -19,32 +24,45 @@ import com.linkedin.transport.trino.TrinoFactory;
 import com.linkedin.transport.test.spi.SqlFunctionCallGenerator;
 import com.linkedin.transport.test.spi.SqlStdTester;
 import com.linkedin.transport.test.spi.ToPlatformTestOutputConverter;
+import io.trino.spi.type.Type;
+import io.trino.sql.query.QueryAssertions;
+import io.trino.testing.LocalQueryRunner;
+import io.trino.type.InternalTypeManager;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
 import static io.trino.type.UnknownType.UNKNOWN;
+import static org.assertj.core.api.Assertions.*;
 
 
-public class TrinoTester extends AbstractTestFunctions implements SqlStdTester {
+public class TrinoTester implements SqlStdTester {
 
   private StdFactory _stdFactory;
   private SqlFunctionCallGenerator _sqlFunctionCallGenerator;
   private ToPlatformTestOutputConverter _toPlatformTestOutputConverter;
+  private Session _session;
+  private FeaturesConfig  _featuresConfig;
+  private LocalQueryRunner _runner;
+  private QueryAssertions _queryAssertions;
 
   public TrinoTester() {
     _stdFactory = null;
     _sqlFunctionCallGenerator = new TrinoSqlFunctionCallGenerator();
     _toPlatformTestOutputConverter = new ToTrinoTestOutputConverter();
+    _session = SessionTestUtils.TEST_SESSION;
+    _featuresConfig = new FeaturesConfig();
+    _runner = LocalQueryRunner.builder(_session).withFeaturesConfig(_featuresConfig).build();
+    _queryAssertions = new QueryAssertions(_runner);
   }
 
   @Override
   public void setup(
       Map<Class<? extends TopLevelStdUDF>, List<Class<? extends StdUDF>>> topLevelStdUDFClassesAndImplementations) {
     // Refresh Trino state during every setup call
-    initTestFunctions();
     for (List<Class<? extends StdUDF>> stdUDFImplementations : topLevelStdUDFClassesAndImplementations.values()) {
       for (Class<? extends StdUDF> stdUDF : stdUDFImplementations) {
-        registerScalarFunction(new TrinoTestStdUDFWrapper(stdUDF));
+        _runner.addFunctions(new InternalFunctionBundle(new SqlFunction[]{new TrinoTestStdUDFWrapper(stdUDF)}));
       }
     }
   }
@@ -59,7 +77,9 @@ public class TrinoTester extends AbstractTestFunctions implements SqlStdTester {
           ImmutableMap.of());
       _stdFactory = new TrinoFactory(
           functionBinding,
-          this.functionAssertions.getMetadata());
+          _runner.getMetadata(),
+          _runner.getFunctionManager(),
+          _session, InternalTypeManager.TESTING_TYPE_MANAGER);
     }
     return _stdFactory;
   }
@@ -75,7 +95,16 @@ public class TrinoTester extends AbstractTestFunctions implements SqlStdTester {
   }
 
   @Override
-  public void assertFunctionCall(String functionCallString, Object expectedOutputData, Object expectedOutputType) {
-    assertFunction(functionCallString, (Type) expectedOutputType, expectedOutputData);
+  public void check(TestCase testCase) {
+    String functionName = testCase.getFunctionCall().getFunctionName();
+    List<Object> parameters = testCase.getFunctionCall().getParameters();
+    List<TestType> testTypes = testCase.getFunctionCall().getInferredParameterTypes();
+    List<String> functionArguments = new ArrayList<>();
+    for (int i = 0; i < parameters.size(); ++i) {
+      functionArguments.add(_sqlFunctionCallGenerator.getFunctionCallArgumentString(parameters.get(i), testTypes.get(i)));
+    }
+    Object expectedOutputType = getPlatformType(testCase.getExpectedOutputType());
+    QueryAssertions.ExpressionAssertProvider expressionAssertProvider = _queryAssertions.function(functionName, functionArguments);
+    assertThat(expressionAssertProvider).hasType((Type) expectedOutputType).isEqualTo(testCase.getExpectedOutput());
   }
 }

--- a/transportable-udfs-trino/src/main/java/com/linkedin/transport/trino/StdUdfWrapper.java
+++ b/transportable-udfs-trino/src/main/java/com/linkedin/transport/trino/StdUdfWrapper.java
@@ -8,7 +8,6 @@ package com.linkedin.transport.trino;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.primitives.Booleans;
 import com.linkedin.transport.api.StdFactory;
 import com.linkedin.transport.api.data.PlatformData;
 import com.linkedin.transport.api.data.StdData;
@@ -24,17 +23,18 @@ import com.linkedin.transport.api.udf.StdUDF7;
 import com.linkedin.transport.api.udf.StdUDF8;
 import com.linkedin.transport.api.udf.TopLevelStdUDF;
 import com.linkedin.transport.typesystem.GenericTypeSignatureElement;
-import io.trino.metadata.FunctionArgumentDefinition;
 import io.trino.metadata.FunctionBinding;
-import io.trino.metadata.FunctionDependencies;
-import io.trino.metadata.FunctionDependencyDeclaration;
-import io.trino.metadata.FunctionKind;
-import io.trino.metadata.FunctionMetadata;
-import io.trino.metadata.Signature;
+import io.trino.metadata.SignatureBinder;
+import io.trino.spi.function.BoundSignature;
+import io.trino.spi.function.FunctionDependencies;
+import io.trino.spi.function.FunctionDependencyDeclaration;
+import io.trino.spi.function.FunctionKind;
+import io.trino.spi.function.FunctionMetadata;
+import io.trino.spi.function.Signature;
 import io.trino.metadata.SqlScalarFunction;
-import io.trino.metadata.TypeVariableConstraint;
-import io.trino.operator.scalar.ChoicesScalarFunctionImplementation;
-import io.trino.operator.scalar.ScalarFunctionImplementation;
+import io.trino.spi.function.TypeVariableConstraint;
+import io.trino.operator.scalar.ChoicesSpecializedSqlScalarFunction;
+import io.trino.operator.scalar.SpecializedSqlScalarFunction;
 import io.trino.spi.classloader.ThreadContextClassLoader;
 import io.trino.spi.function.InvocationConvention;
 import io.trino.spi.type.ArrayType;
@@ -56,10 +56,10 @@ import java.util.stream.IntStream;
 import org.apache.commons.lang3.ClassUtils;
 
 import static com.linkedin.transport.trino.StdUDFUtils.quoteReservedKeywords;
-import static io.trino.metadata.Signature.*;
 import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.*;
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.NULLABLE_RETURN;
 import static io.trino.spi.function.OperatorType.*;
+import static io.trino.spi.function.TypeVariableConstraint.*;
 import static io.trino.sql.analyzer.TypeSignatureTranslator.parseTypeSignature;
 import static io.trino.util.Reflection.*;
 
@@ -71,19 +71,18 @@ public abstract class StdUdfWrapper extends SqlScalarFunction {
   private static final int JITTER_FACTOR = 50;  // to calculate jitter from delay
 
   protected StdUdfWrapper(StdUDF stdUDF) {
-    super(new FunctionMetadata(
-        new Signature(((TopLevelStdUDF) stdUDF).getFunctionName(), getTypeVariableConstraintsForStdUdf(stdUDF),
-            ImmutableList.of(),
-            parseTypeSignature(quoteReservedKeywords(stdUDF.getOutputParameterSignature()),
-                ImmutableSet.of()), stdUDF.getInputParameterSignatures()
-            .stream()
-            .map(typeSignature -> parseTypeSignature(quoteReservedKeywords(typeSignature),
-                ImmutableSet.of()))
-            .collect(Collectors.toList()), false), true, Booleans.asList(stdUDF.getNullableArguments())
-        .stream()
-        .map(FunctionArgumentDefinition::new)
-        .collect(Collectors.toList()), false, false, ((TopLevelStdUDF) stdUDF).getFunctionDescription(),
-        FunctionKind.SCALAR));
+    super(FunctionMetadata.builder(FunctionKind.SCALAR)
+        .nullable()
+        .nondeterministic()
+        .description(((TopLevelStdUDF) stdUDF).getFunctionDescription())
+        .signature(Signature.builder()
+            .name(((TopLevelStdUDF) stdUDF).getFunctionName())
+            .typeVariableConstraints(getTypeVariableConstraintsForStdUdf(stdUDF))
+            .returnType(parseTypeSignature(quoteReservedKeywords(stdUDF.getOutputParameterSignature()), ImmutableSet.of()))
+            .argumentTypes(stdUDF.getInputParameterSignatures().stream()
+                .map(typeSignature -> parseTypeSignature(quoteReservedKeywords(typeSignature), ImmutableSet.of())).collect(Collectors.toList()))
+            .build())
+        .build());
   }
 
   @VisibleForTesting
@@ -118,18 +117,20 @@ public abstract class StdUdfWrapper extends SqlScalarFunction {
   }
 
   @Override
-  public FunctionDependencyDeclaration getFunctionDependencies(FunctionBinding functionBinding) {
+  public FunctionDependencyDeclaration getFunctionDependencies(BoundSignature boundSignature) {
     FunctionDependencyDeclaration.FunctionDependencyDeclarationBuilder builder = FunctionDependencyDeclaration.builder();
 
-    registerNestedDependencies(functionBinding.getBoundSignature().getReturnType(), builder);
-    List<Type> argumentTypes = functionBinding.getBoundSignature().getArgumentTypes();
+    registerNestedDependencies(boundSignature.getReturnType(), builder);
+    List<Type> argumentTypes = boundSignature.getArgumentTypes();
     argumentTypes.forEach(type -> registerNestedDependencies(type, builder));
 
     return builder.build();
   }
 
   @Override
-  public ScalarFunctionImplementation specialize(FunctionBinding functionBinding, FunctionDependencies functionDependencies) {
+  public SpecializedSqlScalarFunction specialize(BoundSignature boundSignature, FunctionDependencies functionDependencies) {
+    FunctionMetadata metadata = getFunctionMetadata();
+    FunctionBinding functionBinding = SignatureBinder.bindFunction(metadata.getFunctionId(), metadata.getSignature(), boundSignature);
     StdFactory stdFactory = new TrinoFactory(functionBinding, functionDependencies);
     StdUDF stdUDF = getStdUDF();
     stdUDF.init(stdFactory);
@@ -141,17 +142,17 @@ public abstract class StdUdfWrapper extends SqlScalarFunction {
         - (new Random()).nextInt(initialJitterInt));
     boolean[] nullableArguments = stdUDF.getAndCheckNullableArguments();
 
-    return new ChoicesScalarFunctionImplementation(
-        functionBinding,
+    return new ChoicesSpecializedSqlScalarFunction(
+        boundSignature,
         NULLABLE_RETURN,
         getNullConventionForArguments(nullableArguments),
-        getMethodHandle(stdUDF, functionBinding, nullableArguments, requiredFilesNextRefreshTime));
+        getMethodHandle(stdUDF, boundSignature, nullableArguments, requiredFilesNextRefreshTime));
   }
 
-  private MethodHandle getMethodHandle(StdUDF stdUDF, FunctionBinding functionBinding, boolean[] nullableArguments,
+  private MethodHandle getMethodHandle(StdUDF stdUDF, BoundSignature boundSignature, boolean[] nullableArguments,
       AtomicLong requiredFilesNextRefreshTime) {
-    Type[] inputTypes = functionBinding.getBoundSignature().getArgumentTypes().toArray(new Type[0]);
-    Type outputType = functionBinding.getBoundSignature().getReturnType();
+    Type[] inputTypes = boundSignature.getArgumentTypes().toArray(new Type[0]);
+    Type outputType = boundSignature.getReturnType();
 
     // Generic MethodHandle for eval where all arguments are of type Object
     Class<?>[] genericMethodHandleArgumentTypes = getMethodHandleArgumentTypes(inputTypes, nullableArguments, true);

--- a/transportable-udfs-trino/src/test/java/com/linkedin/transport/trino/TestGetTypeVariableConstraints.java
+++ b/transportable-udfs-trino/src/test/java/com/linkedin/transport/trino/TestGetTypeVariableConstraints.java
@@ -7,12 +7,12 @@ package com.linkedin.transport.trino;
 
 import com.google.common.collect.ImmutableList;
 import com.linkedin.transport.api.udf.StdUDF;
-import io.trino.metadata.TypeVariableConstraint;
+import io.trino.spi.function.TypeVariableConstraint;
 import java.util.List;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import static io.trino.metadata.Signature.*;
+import static io.trino.spi.function.TypeVariableConstraint.*;
 
 
 public class TestGetTypeVariableConstraints {


### PR DESCRIPTION
The code changes of this PR mainly include
- Bumping the version of Trino used in Transport from v352 to v406
- Replacing the classes defined in trino-main in v352 to the classes defined in trino-spi in v406
- Replacing some classes of test infrastructure in Trino which are deprecated in v406 with the in-use classes

Tests:
- unit tests are passed in all modules of Transport
- major unit tests are passed in `transportable-udfs-examples` except several test cases fail because of the issue in `QueryAssertions` from Trino v406