### PR TITLE
Fix corner case in TransportConnectorMetadata. Exclude com.nimbusds

### DIFF
--- a/transportable-udfs-plugin/src/main/java/com/linkedin/transport/plugin/Defaults.java
+++ b/transportable-udfs-plugin/src/main/java/com/linkedin/transport/plugin/Defaults.java
@@ -78,13 +78,13 @@ class Defaults {
           JavaLanguageVersion.of(17),
           ImmutableList.of(
               DependencyConfiguration.builder(IMPLEMENTATION, "com.linkedin.transport:transportable-udfs-trino", TRANSPORT_VERSION).build(),
-              DependencyConfiguration.builder(COMPILE_ONLY, "io.trino:trino-main", TRINO_VERSION).build()
+              DependencyConfiguration.builder(COMPILE_ONLY, "io.trino:trino-main", TRINO_VERSION).exclude("com.nimbusds").build()
           ),
           ImmutableList.of(
               DependencyConfiguration.builder(RUNTIME_ONLY, "com.linkedin.transport:transportable-udfs-test-trino", TRANSPORT_VERSION).build(),
               // trino-main:tests is a transitive dependency of transportable-udfs-test-trino, but some POM -> IVY
               // converters drop dependencies with classifiers, so we apply this dependency explicitly
-              DependencyConfiguration.builder(RUNTIME_ONLY, "io.trino:trino-main", TRINO_VERSION).classifier("tests").build()
+              DependencyConfiguration.builder(RUNTIME_ONLY, "io.trino:trino-main", TRINO_VERSION).exclude("com.nimbusds").classifier("tests").build()
           ),
           ImmutableList.of(new ThinJarPackaging(), new DistributionPackaging())),
       new Platform(HIVE,

--- a/transportable-udfs-test/transportable-udfs-test-trino/build.gradle
+++ b/transportable-udfs-test/transportable-udfs-test-trino/build.gradle
@@ -13,9 +13,11 @@ dependencies {
   implementation('com.google.guava:guava:24.1-jre')
   implementation(group:'io.trino', name: 'trino-main', version: project.ext.'trino-version') {
     exclude 'group': 'com.google.collections', 'module': 'google-collections'
+    exclude 'group': 'com.nimbusds'
   }
   implementation(group:'io.trino', name: 'trino-main', version: project.ext.'trino-version', classifier: 'tests') {
     exclude 'group': 'com.google.collections', 'module': 'google-collections'
+    exclude 'group': 'com.nimbusds'
   }
   implementation group: 'io.airlift', name: 'testing', version: '221'
   // The io.airlift.slice dependency below has to match its counterpart in trino-root's pom.xml file

--- a/transportable-udfs-trino-plugin/build.gradle
+++ b/transportable-udfs-trino-plugin/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'java'
 apply plugin: 'distribution'
+apply plugin: 'maven-publish'
 
 java {
   toolchain.languageVersion.set(JavaLanguageVersion.of(17))
@@ -29,6 +30,14 @@ distributions {
     contents {
       from jar
       from project.configurations.runtimeClasspath
+    }
+  }
+}
+
+publishing {
+  publications {
+    maven(MavenPublication) {
+      artifact(tasks.distTar)
     }
   }
 }

--- a/transportable-udfs-trino-plugin/build.gradle
+++ b/transportable-udfs-trino-plugin/build.gradle
@@ -14,9 +14,13 @@ dependencies {
   implementation (group:'io.airlift', name: 'log', version: '221')
   implementation (group:'com.google.guava', name: 'guava', version: '24.1-jre')
   implementation (group:'io.trino', name: 'trino-plugin-toolkit', version: project.ext.'trino-version')
-  runtimeOnly (group:'io.trino', name: 'trino-main', version: project.ext.'trino-version')
+  runtimeOnly (group:'io.trino', name: 'trino-main', version: project.ext.'trino-version') {
+    exclude 'group': 'com.nimbusds'
+  }
   compileOnly(group:'io.trino', name: 'trino-spi', version: project.ext.'trino-version')
-  testImplementation (group:'io.trino', name: 'trino-main', version: project.ext.'trino-version')
+  testImplementation (group:'io.trino', name: 'trino-main', version: project.ext.'trino-version') {
+    exclude 'group': 'com.nimbusds'
+  }
 }
 
 // packaging as a shaded jar following the guideline from Trino plugin

--- a/transportable-udfs-trino-plugin/src/main/java/com/linkedin/transport/trino/TransportConnectorFactory.java
+++ b/transportable-udfs-trino-plugin/src/main/java/com/linkedin/transport/trino/TransportConnectorFactory.java
@@ -24,7 +24,7 @@ import static java.util.Objects.*;
 public class TransportConnectorFactory implements ConnectorFactory {
   @Override
   public String getName() {
-    return "TRANSPORT";
+    return "transport";
   }
 
   @Override

--- a/transportable-udfs-trino-plugin/src/main/java/com/linkedin/transport/trino/TransportConnectorMetadata.java
+++ b/transportable-udfs-trino-plugin/src/main/java/com/linkedin/transport/trino/TransportConnectorMetadata.java
@@ -16,6 +16,8 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+
 /**
  * This class implements the interface of ConnectorMetadata from Trino SPI as a part of Trino plugin
  * to load UDF classes in Trino server following the development guideline
@@ -44,5 +46,10 @@ public class TransportConnectorMetadata implements ConnectorMetadata {
   @Override
   public FunctionMetadata getFunctionMetadata(ConnectorSession session, FunctionId functionId) {
     return functions.get(functionId).getFunctionMetadata();
+  }
+
+  @Override
+  public Collection<FunctionMetadata> listFunctions(ConnectorSession session, String schemaName) {
+    return functions.values().stream().map(StdUdfWrapper::getFunctionMetadata).collect(toImmutableSet());
   }
 }

--- a/transportable-udfs-trino-plugin/src/main/java/com/linkedin/transport/trino/TransportConnectorMetadata.java
+++ b/transportable-udfs-trino-plugin/src/main/java/com/linkedin/transport/trino/TransportConnectorMetadata.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static java.util.Locale.ENGLISH;
 
 /**
  * This class implements the interface of ConnectorMetadata from Trino SPI as a part of Trino plugin
@@ -41,7 +42,8 @@ public class TransportConnectorMetadata implements ConnectorMetadata {
   @Override
   public Collection<FunctionMetadata> getFunctions(ConnectorSession session, SchemaFunctionName name) {
     return functions.values().stream().map(StdUdfWrapper::getFunctionMetadata)
-        .filter(e -> e.getCanonicalName().equals(name.getFunctionName()))
+        // Function are expected to be called case agnostic
+        .filter(e -> e.getCanonicalName().toLowerCase(ENGLISH).equals(name.getFunctionName()))
         .collect(Collectors.toList());
   }
 

--- a/transportable-udfs-trino-plugin/src/main/java/com/linkedin/transport/trino/TransportConnectorMetadata.java
+++ b/transportable-udfs-trino-plugin/src/main/java/com/linkedin/transport/trino/TransportConnectorMetadata.java
@@ -5,6 +5,7 @@
  */
 package com.linkedin.transport.trino;
 
+import com.google.common.collect.ImmutableList;
 import io.trino.spi.connector.ConnectorMetadata;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.function.BoundSignature;
@@ -13,6 +14,7 @@ import io.trino.spi.function.FunctionId;
 import io.trino.spi.function.FunctionMetadata;
 import io.trino.spi.function.SchemaFunctionName;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -51,5 +53,10 @@ public class TransportConnectorMetadata implements ConnectorMetadata {
   @Override
   public Collection<FunctionMetadata> listFunctions(ConnectorSession session, String schemaName) {
     return functions.values().stream().map(StdUdfWrapper::getFunctionMetadata).collect(toImmutableSet());
+  }
+
+  @Override
+  public List<String> listSchemaNames(ConnectorSession session) {
+    return ImmutableList.of("transport");
   }
 }

--- a/transportable-udfs-trino-plugin/src/test/java/com/linkedin/transport/trino/TransportPluginTest.java
+++ b/transportable-udfs-trino-plugin/src/test/java/com/linkedin/transport/trino/TransportPluginTest.java
@@ -51,6 +51,11 @@ public class TransportPluginTest {
     MaterializedResult result = queryRunner.execute(query);
     Assert.assertEquals(result.getRowCount(), 1);
     Assert.assertEquals(((int) result.getMaterializedRows().get(0).getField(0)), 3);
+
+    String camelCaseQuery = "SELECT Array_Element_At(array[1,2,3], 2)";
+    MaterializedResult camelCaseResult = queryRunner.execute(camelCaseQuery);
+    Assert.assertEquals(camelCaseResult.getRowCount(), 1);
+    Assert.assertEquals(((int) camelCaseResult.getMaterializedRows().get(0).getField(0)), 3);
   }
 
   @Test

--- a/transportable-udfs-trino-plugin/src/test/java/com/linkedin/transport/trino/TransportPluginTest.java
+++ b/transportable-udfs-trino-plugin/src/test/java/com/linkedin/transport/trino/TransportPluginTest.java
@@ -31,13 +31,13 @@ public class TransportPluginTest {
 
   @BeforeClass
   public void setUp() {
-    SqlPath sqlPath = new SqlPath("LINKEDIN.TRANSPORT");
+    SqlPath sqlPath = new SqlPath("LINKEDIN.transport");
     FeaturesConfig featuresConfig = new FeaturesConfig();
     Session session = TestingSession.testSessionBuilder().setPath(sqlPath).setClientCapabilities((Set) Arrays.stream(
         ClientCapabilities.values()).map(Enum::toString).collect(ImmutableSet.toImmutableSet())).build();
     queryRunner = LocalQueryRunner.builder(session).withFeaturesConfig(featuresConfig).build();
     queryRunner.installPlugin(new TransportPlugin());
-    queryRunner.createCatalog("LINKEDIN", "TRANSPORT", ImmutableMap.of("transport.udf.repo", udfRepoDir));
+    queryRunner.createCatalog("LINKEDIN", "transport", ImmutableMap.of("transport.udf.repo", udfRepoDir));
   }
 
   @AfterClass

--- a/transportable-udfs-trino-plugin/src/test/java/com/linkedin/transport/trino/TransportPluginTest.java
+++ b/transportable-udfs-trino-plugin/src/test/java/com/linkedin/transport/trino/TransportPluginTest.java
@@ -18,24 +18,35 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.*;
 
 
 public class TransportPluginTest {
-  private static final String TRANSPORT_UDF_REPO_DIR =  "transport-udf-repo";
+  private final String udfRepoDir = getClass().getClassLoader().getResource("transport-udf-repo").getPath();
+  private LocalQueryRunner queryRunner;
 
-  @Test
-  public void testTransportPluginInitialization() {
-    String udfRepoDir = getClass().getClassLoader().getResource(TRANSPORT_UDF_REPO_DIR).getPath();
+  @BeforeClass
+  public void setUp() {
     SqlPath sqlPath = new SqlPath("LINKEDIN.TRANSPORT");
     FeaturesConfig featuresConfig = new FeaturesConfig();
     Session session = TestingSession.testSessionBuilder().setPath(sqlPath).setClientCapabilities((Set) Arrays.stream(
         ClientCapabilities.values()).map(Enum::toString).collect(ImmutableSet.toImmutableSet())).build();
-    LocalQueryRunner queryRunner = LocalQueryRunner.builder(session).withFeaturesConfig(featuresConfig).build();
+    queryRunner = LocalQueryRunner.builder(session).withFeaturesConfig(featuresConfig).build();
     queryRunner.installPlugin(new TransportPlugin());
     queryRunner.createCatalog("LINKEDIN", "TRANSPORT", ImmutableMap.of("transport.udf.repo", udfRepoDir));
+  }
+
+  @AfterClass
+  public void tearDown() {
+    queryRunner.close();
+  }
+
+  @Test
+  public void testTransportUdfIsAccessible() {
     String query = "SELECT array_element_at(array[1,2,3], 2)";
     MaterializedResult result = queryRunner.execute(query);
     Assert.assertEquals(result.getRowCount(), 1);
@@ -43,8 +54,15 @@ public class TransportPluginTest {
   }
 
   @Test
+  public void testTransportUdfInShowFunctions() {
+    String showFunctionQuery = "SHOW FUNCTIONS LIKE 'array_element_at'";
+    MaterializedResult showFunctionResult = queryRunner.execute(showFunctionQuery);
+    Assert.assertEquals(showFunctionResult.getRowCount(), 1);
+    Assert.assertEquals(((String) showFunctionResult.getMaterializedRows().get(0).getField(0)), "array_element_at");
+  }
+
+  @Test
   public void testTransportUDFClassLoader() {
-    String udfRepoDir = getClass().getClassLoader().getResource(TRANSPORT_UDF_REPO_DIR).getPath();
     TransportConfig config = new TransportConfig();
     config.setTransportUdfRepo(udfRepoDir);
     TransportConnector connector = new TransportConnector(config);

--- a/transportable-udfs-trino/build.gradle
+++ b/transportable-udfs-trino/build.gradle
@@ -10,12 +10,15 @@ dependencies {
   implementation project(':transportable-udfs-utils')
   compileOnly(group:'io.trino', name: 'trino-main', version: project.ext.'trino-version') {
     exclude 'group': 'com.google.collections', 'module': 'google-collections'
+    exclude 'group': 'com.nimbusds'
   }
   testImplementation(group:'io.trino', name: 'trino-main', version: project.ext.'trino-version') {
     exclude 'group': 'com.google.collections', 'module': 'google-collections'
+    exclude 'group': 'com.nimbusds'
   }
   testImplementation(group:'io.trino', name: 'trino-main', version: project.ext.'trino-version', classifier: 'tests') {
     exclude 'group': 'com.google.collections', 'module': 'google-collections'
+    exclude 'group': 'com.nimbusds'
   }
   compileOnly(group:'io.trino', name: 'trino-spi', version: project.ext.'trino-version')
   implementation('org.apache.hadoop:hadoop-hdfs:2.7.4')


### PR DESCRIPTION
## Summary
* In Trino
  * `SHOW FUNCTIONS` retrieves function metadata from `ConnectorMetadata#listFunctions`
  * `SHOW FUNCTIONS FROM ...` will check if the provided schema exists by `ConnectorMetadata#listSchemaNames`
  * Schema name is expected to be in lower case.
  * Make `TransportConnectorMetadata#getFunctions` compare in lower case because the schema function name is expected so
* Refactor `TransportPluginTest` usage of `LocalQueryRunner`
* Exclude dependencies with vulnerabilities under group id `com.nimbusds`. Transport does not depend on any class that uses them.
* Publish `.tar` distribution of `transportable-udfs-trino-plugin`

## Testing Done
* Added unit test case for calling function name with camel case
* Added unit test case for `SHOW FUNCTIONS` usage
* Local end-to-end testing
* `./gradlew transportable-udfs-trino-plugin:dependencies | grep nimbusds` and `./gradlew transportable-udfs-trino:dependencies | grep nimbusds` shows none