### PR TITLE
publishing tar file for transportable-udfs-trino-plugin

### DIFF
--- a/transportable-udfs-trino-plugin/build.gradle
+++ b/transportable-udfs-trino-plugin/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'java'
 apply plugin: 'distribution'
+apply plugin: 'maven-publish'
 
 java {
   toolchain.languageVersion.set(JavaLanguageVersion.of(17))
@@ -25,6 +26,14 @@ distributions {
     contents {
       from jar
       from project.configurations.runtimeClasspath
+    }
+  }
+}
+
+publishing {
+  publications {
+    maven(MavenPublication) {
+      artifact(tasks.distTar)
     }
   }
 }


### PR DESCRIPTION
Test locally with the command: `./gradlew publishToMavenLocal` and verify the tar file is published to the local Maven repo