### PR TITLE
Replace maven with javaLibrary to avoid warning in publish task of transportable-udfs-trino-plugin

### DIFF
--- a/transportable-udfs-trino-plugin/build.gradle
+++ b/transportable-udfs-trino-plugin/build.gradle
@@ -36,8 +36,8 @@ distributions {
 
 publishing {
   publications {
-    maven(MavenPublication) {
-      artifact(tasks.distTar)
+    javaLibrary(MavenPublication) {
+      artifact distTar
     }
   }
 }


### PR DESCRIPTION
## Summary
As tar file needs to be published for `transportable-udfs-trino-plugin`, a publish task is added by define a subtask of `maven`. However, it causes a warning during the execution of publish task 
```
Multiple publications with coordinates 'com.linkedin.transport:transportable-udfs-trino-plugin:0.0.90' are published to repository 'sonatype'. The publications 'javaLibrary' in project ':transportable-udfs-trino-plugin' and 'maven' in project ':transportable-udfs-trino-plugin' will overwrite each other!
```
as shown in https://github.com/linkedin/transport/actions/runs/4857796463/jobs/8658619601
Therefore,`maven` subtask is replaced by `javaLibrary` in `build.gradle` of `transportable-udfs-trino-plugin` to avoid this warning.

## Test
In `transportable-udfs-trino-plugin` 
./gradlew clean build
./gradlew publishToMavenLocal