### PR TITLE
Bump Trino dependency version to 414

### DIFF
--- a/defaultEnvironment.gradle
+++ b/defaultEnvironment.gradle
@@ -7,7 +7,7 @@ subprojects {
     mavenCentral()
     jcenter()
   }
-  project.ext.setProperty('trino-version', '406')
+  project.ext.setProperty('trino-version', '414')
   project.ext.setProperty('airlift-slice-version', '0.44')
   project.ext.setProperty('spark-group', 'org.apache.spark')
   project.ext.setProperty('spark2-version', '2.3.0')

--- a/transportable-udfs-plugin/build.gradle
+++ b/transportable-udfs-plugin/build.gradle
@@ -19,7 +19,7 @@ def writeVersionInfo = { file ->
   ant.propertyfile(file: file) {
     entry(key: "transport-version", value: version)
     entry(key: "hive-version", value: '1.2.2')
-    entry(key: "trino-version", value: '406')
+    entry(key: "trino-version", value: '414')
     entry(key: "spark_2.11-version", value: '2.3.0')
     entry(key: "spark_2.12-version", value: '3.1.1')
     entry(key: "scala-version", value: '2.11.8')

--- a/transportable-udfs-test/transportable-udfs-test-trino/src/main/java/com/linkedin/transport/test/trino/TrinoTester.java
+++ b/transportable-udfs-test/transportable-udfs-test-trino/src/main/java/com/linkedin/transport/test/trino/TrinoTester.java
@@ -65,7 +65,7 @@ public class TrinoTester implements SqlStdTester {
     _stdFactory = null;
     _sqlFunctionCallGenerator = new TrinoSqlFunctionCallGenerator();
     _toPlatformTestOutputConverter = new ToTrinoTestOutputConverter();
-    SqlPath sqlPath = new SqlPath("LINKEDIN.TRANSPORT");
+    SqlPath sqlPath = new SqlPath("LINKEDIN.transport");
     _session = TestingSession.testSessionBuilder().setPath(sqlPath).setClientCapabilities((Set) Arrays.stream(
         ClientCapabilities.values()).map(Enum::toString).collect(ImmutableSet.toImmutableSet())).build();
     _featuresConfig = new FeaturesConfig();
@@ -90,7 +90,7 @@ public class TrinoTester implements SqlStdTester {
     ConnectorFactory connectorFactory = new ConnectorFactory() {
       @Override
       public String getName() {
-        return "TRANSPORT";
+        return "transport";
       }
       @Override
       public Connector create(String catalogName, Map<String, String> config, ConnectorContext context) {


### PR DESCRIPTION
## Summary
* Bump Trino main version to 414 to avoid dependency vulnerability
* Fix tests as in recent version Trino enforces connector name to be strictly lower-case