### PR TITLE
Remove slf4j-api 1.8+ and use nimbus-jose-jwt 9.31

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,11 @@ subprojects {
       //    library, but not any SLF4J-binding or any underlying logging system."
       // Our dependencies (e.g. hadoop-common) do bring in slf4j-log4j12 in their dependency graph so we exclude them
       exclude group: 'org.slf4j', module: 'slf4j-log4j12'
+
+      resolutionStrategy.dependencySubstitution {
+        substitute module('com.nimbusds:nimbus-jose-jwt:9.14') using module('com.nimbusds:nimbus-jose-jwt:9.31')
+        substitute module('org.slf4j:slf4j-api') using module ('org.slf4j:slf4j-api:1.7.25')
+      }
     }
   }
 

--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,24 @@ subprojects {
       resolutionStrategy.dependencySubstitution {
         substitute module('com.nimbusds:nimbus-jose-jwt:9.14') using module('com.nimbusds:nimbus-jose-jwt:9.31')
         substitute module('org.slf4j:slf4j-api') using module ('org.slf4j:slf4j-api:1.7.25')
+        // Downgrade to airlift 221 because airlift 222+ consumes slf4j-api ver. 2+
+        substitute module('io.airlift:bootstrap:222') using module('io.airlift:bootstrap:221')
+        substitute module('io.airlift:concurrent:222') using module('io.airlift:concurrent:221')
+        substitute module('io.airlift:configuration:222') using module('io.airlift:configuration:221')
+        substitute module('io.airlift:discovery:222') using module('io.airlift:discovery:221')
+        substitute module('io.airlift:event:222') using module('io.airlift:event:221')
+        substitute module('io.airlift:http-client:222') using module('io.airlift:http-client:221')
+        substitute module('io.airlift:http-server:222') using module('io.airlift:http-server:221')
+        substitute module('io.airlift:jaxrs:222') using module('io.airlift:jaxrs:221')
+        substitute module('io.airlift:jmx:222') using module('io.airlift:jmx:221')
+        substitute module('io.airlift:jmx-http:222') using module('io.airlift:jmx-http:221')
+        substitute module('io.airlift:json:222') using module('io.airlift:json:221')
+        substitute module('io.airlift:log:222') using module('io.airlift:log:221')
+        substitute module('io.airlift:log-manager:222') using module('io.airlift:log-manager:221')
+        substitute module('io.airlift:node:222') using module('io.airlift:node:221')
+        substitute module('io.airlift:security:222') using module('io.airlift:security:221')
+        substitute module('io.airlift:stats:222') using module('io.airlift:stats:221')
+        substitute module('io.airlift:trace-token:222') using module('io.airlift:trace-token:221')
       }
     }
   }

--- a/transportable-udfs-plugin/src/main/java/com/linkedin/transport/plugin/Defaults.java
+++ b/transportable-udfs-plugin/src/main/java/com/linkedin/transport/plugin/Defaults.java
@@ -78,15 +78,13 @@ class Defaults {
           JavaLanguageVersion.of(17),
           ImmutableList.of(
               DependencyConfiguration.builder(IMPLEMENTATION, "com.linkedin.transport:transportable-udfs-trino", TRANSPORT_VERSION).build(),
-              DependencyConfiguration.builder(COMPILE_ONLY, "io.trino:trino-main", TRINO_VERSION)
-                  .exclude("com.nimbusds").exclude("org.slf4j", "slf4j-api").build()
+              DependencyConfiguration.builder(COMPILE_ONLY, "io.trino:trino-main", TRINO_VERSION).exclude("org.slf4j", "slf4j-api").build()
           ),
           ImmutableList.of(
               DependencyConfiguration.builder(RUNTIME_ONLY, "com.linkedin.transport:transportable-udfs-test-trino", TRANSPORT_VERSION).build(),
               // trino-main:tests is a transitive dependency of transportable-udfs-test-trino, but some POM -> IVY
               // converters drop dependencies with classifiers, so we apply this dependency explicitly
-              DependencyConfiguration.builder(RUNTIME_ONLY, "io.trino:trino-main", TRINO_VERSION)
-                  .exclude("com.nimbusds").exclude("org.slf4j", "slf4j-api").classifier("tests").build()
+              DependencyConfiguration.builder(RUNTIME_ONLY, "io.trino:trino-main", TRINO_VERSION).exclude("org.slf4j", "slf4j-api").classifier("tests").build()
           ),
           ImmutableList.of(new ThinJarPackaging(), new DistributionPackaging())),
       new Platform(HIVE,

--- a/transportable-udfs-plugin/src/main/java/com/linkedin/transport/plugin/Defaults.java
+++ b/transportable-udfs-plugin/src/main/java/com/linkedin/transport/plugin/Defaults.java
@@ -78,13 +78,15 @@ class Defaults {
           JavaLanguageVersion.of(17),
           ImmutableList.of(
               DependencyConfiguration.builder(IMPLEMENTATION, "com.linkedin.transport:transportable-udfs-trino", TRANSPORT_VERSION).build(),
-              DependencyConfiguration.builder(COMPILE_ONLY, "io.trino:trino-main", TRINO_VERSION).exclude("com.nimbusds").build()
+              DependencyConfiguration.builder(COMPILE_ONLY, "io.trino:trino-main", TRINO_VERSION)
+                  .exclude("com.nimbusds").exclude("org.slf4j", "slf4j-api").build()
           ),
           ImmutableList.of(
               DependencyConfiguration.builder(RUNTIME_ONLY, "com.linkedin.transport:transportable-udfs-test-trino", TRANSPORT_VERSION).build(),
               // trino-main:tests is a transitive dependency of transportable-udfs-test-trino, but some POM -> IVY
               // converters drop dependencies with classifiers, so we apply this dependency explicitly
-              DependencyConfiguration.builder(RUNTIME_ONLY, "io.trino:trino-main", TRINO_VERSION).exclude("com.nimbusds").classifier("tests").build()
+              DependencyConfiguration.builder(RUNTIME_ONLY, "io.trino:trino-main", TRINO_VERSION)
+                  .exclude("com.nimbusds").exclude("org.slf4j", "slf4j-api").classifier("tests").build()
           ),
           ImmutableList.of(new ThinJarPackaging(), new DistributionPackaging())),
       new Platform(HIVE,

--- a/transportable-udfs-test/transportable-udfs-test-trino/build.gradle
+++ b/transportable-udfs-test/transportable-udfs-test-trino/build.gradle
@@ -13,11 +13,9 @@ dependencies {
   implementation('com.google.guava:guava:24.1-jre')
   implementation(group:'io.trino', name: 'trino-main', version: project.ext.'trino-version') {
     exclude 'group': 'com.google.collections', 'module': 'google-collections'
-    exclude 'group': 'com.nimbusds'
   }
   implementation(group:'io.trino', name: 'trino-main', version: project.ext.'trino-version', classifier: 'tests') {
     exclude 'group': 'com.google.collections', 'module': 'google-collections'
-    exclude 'group': 'com.nimbusds'
   }
   implementation group: 'io.airlift', name: 'testing', version: '221'
   // The io.airlift.slice dependency below has to match its counterpart in trino-root's pom.xml file

--- a/transportable-udfs-trino-plugin/build.gradle
+++ b/transportable-udfs-trino-plugin/build.gradle
@@ -15,13 +15,9 @@ dependencies {
   implementation (group:'io.airlift', name: 'log', version: '221')
   implementation (group:'com.google.guava', name: 'guava', version: '24.1-jre')
   implementation (group:'io.trino', name: 'trino-plugin-toolkit', version: project.ext.'trino-version')
-  runtimeOnly (group:'io.trino', name: 'trino-main', version: project.ext.'trino-version') {
-    exclude 'group': 'com.nimbusds'
-  }
+  runtimeOnly (group:'io.trino', name: 'trino-main', version: project.ext.'trino-version')
   compileOnly(group:'io.trino', name: 'trino-spi', version: project.ext.'trino-version')
-  testImplementation (group:'io.trino', name: 'trino-main', version: project.ext.'trino-version') {
-    exclude 'group': 'com.nimbusds'
-  }
+  testImplementation (group:'io.trino', name: 'trino-main', version: project.ext.'trino-version')
 }
 
 // packaging as a shaded jar following the guideline from Trino plugin

--- a/transportable-udfs-trino/build.gradle
+++ b/transportable-udfs-trino/build.gradle
@@ -10,15 +10,12 @@ dependencies {
   implementation project(':transportable-udfs-utils')
   compileOnly(group:'io.trino', name: 'trino-main', version: project.ext.'trino-version') {
     exclude 'group': 'com.google.collections', 'module': 'google-collections'
-    exclude 'group': 'com.nimbusds'
   }
   testImplementation(group:'io.trino', name: 'trino-main', version: project.ext.'trino-version') {
     exclude 'group': 'com.google.collections', 'module': 'google-collections'
-    exclude 'group': 'com.nimbusds'
   }
   testImplementation(group:'io.trino', name: 'trino-main', version: project.ext.'trino-version', classifier: 'tests') {
     exclude 'group': 'com.google.collections', 'module': 'google-collections'
-    exclude 'group': 'com.nimbusds'
   }
   compileOnly(group:'io.trino', name: 'trino-spi', version: project.ext.'trino-version')
   implementation('org.apache.hadoop:hadoop-hdfs:2.7.4')


### PR DESCRIPTION
## Summary
* `slf4j-api` ver. 1.8+ is not backward compatible
* `nimbus-jose-jwt` ver. 9.31 is non-vulnerable

## Testing
```
% ./gradlew transportable-udfs-trino:dependencies | grep nimbus-jose-jwt 
|    +--- com.nimbusds:nimbus-jose-jwt:9.14 -> 9.31
|    |    \--- com.nimbusds:nimbus-jose-jwt:9.14 -> 9.31 (*)
|    +--- com.nimbusds:nimbus-jose-jwt:9.14 -> 9.31
|    |    \--- com.nimbusds:nimbus-jose-jwt:9.14 -> 9.31 (*)
|    +--- com.nimbusds:nimbus-jose-jwt:9.14 -> 9.31
|    |    \--- com.nimbusds:nimbus-jose-jwt:9.14 -> 9.31 (*)
% ./gradlew transportable-udfs-trino-plugin:dependencies | grep nimbus-jose-jwt
     +--- com.nimbusds:nimbus-jose-jwt:9.14 -> 9.31
     |    \--- com.nimbusds:nimbus-jose-jwt:9.14 -> 9.31 (*)
     +--- com.nimbusds:nimbus-jose-jwt:9.14 -> 9.31
     |    \--- com.nimbusds:nimbus-jose-jwt:9.14 -> 9.31 (*)
|    +--- com.nimbusds:nimbus-jose-jwt:9.14 -> 9.31
|    |    \--- com.nimbusds:nimbus-jose-jwt:9.14 -> 9.31 (*)
```
All lifted to ver. 9.31

```
% ./gradlew transportable-udfs-trino:dependencies | grep slf4j-api
|    |    \--- org.slf4j:slf4j-api:1.7.7 -> 1.7.25
|    |    \--- org.slf4j:slf4j-api:1.7.32 -> 1.7.25
|         +--- org.slf4j:slf4j-api:1.7.10 -> 1.7.25
|         |    \--- org.slf4j:slf4j-api:1.6.4 -> 1.7.25
|         |    +--- org.slf4j:slf4j-api:1.7.10 -> 1.7.25
|         |    |    |    \--- org.slf4j:slf4j-api:1.7.5 -> 1.7.25
|         |    |    |    \--- org.slf4j:slf4j-api:1.7.5 -> 1.7.25
|         |    |    |    \--- org.slf4j:slf4j-api:1.7.5 -> 1.7.25
|         |    |    \--- org.slf4j:slf4j-api:1.7.5 -> 1.7.25
|         |    |    +--- org.slf4j:slf4j-api:1.6.1 -> 1.7.25
|         |         |    +--- org.slf4j:slf4j-api:1.7.6 -> 1.7.25
|    |    +--- org.slf4j:slf4j-api:1.7.10 -> 1.7.25
|    |    |    \--- org.slf4j:slf4j-api:1.6.4 -> 1.7.25
|    |    |    +--- org.slf4j:slf4j-api:1.7.10 -> 1.7.25
|    |    |    |    |    \--- org.slf4j:slf4j-api:1.7.5 -> 1.7.25
|    |    |    |    |    \--- org.slf4j:slf4j-api:1.7.5 -> 1.7.25
|    |    |    |    |    \--- org.slf4j:slf4j-api:1.7.5 -> 1.7.25
|    |    |    |    \--- org.slf4j:slf4j-api:1.7.5 -> 1.7.25
|    |    |    |    +--- org.slf4j:slf4j-api:1.6.1 -> 1.7.25
|    |    |         |    +--- org.slf4j:slf4j-api:1.7.6 -> 1.7.25
|         |    +--- org.slf4j:slf4j-api:1.7.10 -> 1.7.25
|         +--- org.slf4j:slf4j-api:1.7.10 -> 1.7.25
|         +--- org.slf4j:slf4j-api:1.7.10 -> 1.7.25
|         |    \--- org.slf4j:slf4j-api:1.6.4 -> 1.7.25
|         |    +--- org.slf4j:slf4j-api:1.7.10 -> 1.7.25
|         |    |    |    \--- org.slf4j:slf4j-api:1.7.5 -> 1.7.25
|         |    |    |    \--- org.slf4j:slf4j-api:1.7.5 -> 1.7.25
|         |    |    |    \--- org.slf4j:slf4j-api:1.7.5 -> 1.7.25
|         |    |    \--- org.slf4j:slf4j-api:1.7.5 -> 1.7.25
|         |    |    +--- org.slf4j:slf4j-api:1.6.1 -> 1.7.25
|         |         |    +--- org.slf4j:slf4j-api:1.7.6 -> 1.7.25
|    \--- org.slf4j:slf4j-api:1.7.25
|    |    \--- org.slf4j:slf4j-api:1.7.7 -> 1.7.25
|    |    \--- org.slf4j:slf4j-api:1.7.32 -> 1.7.25
|    |    +--- org.slf4j:slf4j-api:1.7.10 -> 1.7.25
|    |    |    \--- org.slf4j:slf4j-api:1.6.4 -> 1.7.25
|    |    |    +--- org.slf4j:slf4j-api:1.7.10 -> 1.7.25
|    |    |    |    |    \--- org.slf4j:slf4j-api:1.7.5 -> 1.7.25
|    |    |    |    |    \--- org.slf4j:slf4j-api:1.7.5 -> 1.7.25
|    |    |    |    |    \--- org.slf4j:slf4j-api:1.7.5 -> 1.7.25
|    |    |    |    \--- org.slf4j:slf4j-api:1.7.5 -> 1.7.25
|    |    |    |    +--- org.slf4j:slf4j-api:1.6.1 -> 1.7.25
|    |    |         |    +--- org.slf4j:slf4j-api:1.7.6 -> 1.7.25
|         |    +--- org.slf4j:slf4j-api:1.7.10 -> 1.7.25
|         +--- org.slf4j:slf4j-api:1.7.10 -> 1.7.25
|    \--- org.slf4j:slf4j-api:1.7.25
|    |    |    |    |    \--- org.slf4j:slf4j-api:2.0.6 -> 1.7.25
|    |    |    |    |    \--- org.slf4j:slf4j-api:2.0.6 -> 1.7.25
|    |    |    |    |    +--- org.slf4j:slf4j-api:1.7.25
|    |    |    |    |    \--- org.slf4j:slf4j-api:2.0.6 -> 1.7.25
|    |    \--- org.slf4j:slf4j-api:1.7.7 -> 1.7.25
|    |    \--- org.slf4j:slf4j-api:1.7.32 -> 1.7.25

% ./gradlew transportable-udfs-trino-plugin:dependencies | grep slf4j-api
|    |    |    +--- org.slf4j:slf4j-api:1.7.10 -> 1.7.25
|    |    |    |    \--- org.slf4j:slf4j-api:1.6.4 -> 1.7.25
|    |    |    |    +--- org.slf4j:slf4j-api:1.7.10 -> 1.7.25
|    |    |    |    |    |    \--- org.slf4j:slf4j-api:1.7.5 -> 1.7.25
|    |    |    |    |    |    \--- org.slf4j:slf4j-api:1.7.5 -> 1.7.25
|    |    |    |    |    |    \--- org.slf4j:slf4j-api:1.7.5 -> 1.7.25
|    |    |    |    |    \--- org.slf4j:slf4j-api:1.7.5 -> 1.7.25
|    |    |    |    |    +--- org.slf4j:slf4j-api:1.6.1 -> 1.7.25
|    |    |    |         |    +--- org.slf4j:slf4j-api:1.7.6 -> 1.7.25
|    |         |    +--- org.slf4j:slf4j-api:1.7.10 -> 1.7.25
|    |         +--- org.slf4j:slf4j-api:1.7.10 -> 1.7.25
|    |    |    \--- org.slf4j:slf4j-api:2.0.6 -> 1.7.25
|    |    |    \--- org.slf4j:slf4j-api:2.0.6 -> 1.7.25
|    |    |    +--- org.slf4j:slf4j-api:1.7.25
|    |    |    \--- org.slf4j:slf4j-api:2.0.6 -> 1.7.25
     |    \--- org.slf4j:slf4j-api:1.7.7 -> 1.7.25
     |    \--- org.slf4j:slf4j-api:1.7.32 -> 1.7.25
|    \--- org.slf4j:slf4j-api:1.7.25
     |    \--- org.slf4j:slf4j-api:1.7.7 -> 1.7.25
     |    \--- org.slf4j:slf4j-api:1.7.32 -> 1.7.25
|    |    |    +--- org.slf4j:slf4j-api:1.7.10 -> 1.7.25
|    |    |    |    \--- org.slf4j:slf4j-api:1.6.4 -> 1.7.25
|    |    |    |    +--- org.slf4j:slf4j-api:1.7.10 -> 1.7.25
|    |    |    |    |    |    \--- org.slf4j:slf4j-api:1.7.5 -> 1.7.25
|    |    |    |    |    |    \--- org.slf4j:slf4j-api:1.7.5 -> 1.7.25
|    |    |    |    |    |    \--- org.slf4j:slf4j-api:1.7.5 -> 1.7.25
|    |    |    |    |    \--- org.slf4j:slf4j-api:1.7.5 -> 1.7.25
|    |    |    |    |    +--- org.slf4j:slf4j-api:1.6.1 -> 1.7.25
|    |    |    |         |    +--- org.slf4j:slf4j-api:1.7.6 -> 1.7.25
|    |         |    +--- org.slf4j:slf4j-api:1.7.10 -> 1.7.25
|    |         +--- org.slf4j:slf4j-api:1.7.10 -> 1.7.25
|    |    |    \--- org.slf4j:slf4j-api:2.0.6 -> 1.7.25
|    |    |    \--- org.slf4j:slf4j-api:2.0.6 -> 1.7.25
|    |    |    +--- org.slf4j:slf4j-api:1.7.25
|    |    |    \--- org.slf4j:slf4j-api:2.0.6 -> 1.7.25
|    |    \--- org.slf4j:slf4j-api:1.7.7 -> 1.7.25
|    |    \--- org.slf4j:slf4j-api:1.7.32 -> 1.7.25
     \--- org.slf4j:slf4j-api:1.7.25
```
All fixed to ver. 1.7.25

```
% ./gradlew transportable-udfs-trino:dependencies | grep slf4j-simple
+--- org.slf4j:slf4j-simple:1.7.25
+--- org.slf4j:slf4j-simple:1.7.25 (n)
+--- org.slf4j:slf4j-simple:1.7.25
% ./gradlew transportable-udfs-trino-plugin:dependencies | grep slf4j-simple
+--- org.slf4j:slf4j-simple:1.7.25
+--- org.slf4j:slf4j-simple:1.7.25 (n)
\--- org.slf4j:slf4j-simple:1.7.25
```

```
% ./gradlew clean build publish
```
