### PR TITLE
Remove trino-spi.jar in distribution

### DIFF
--- a/transportable-udfs-trino-plugin/build.gradle
+++ b/transportable-udfs-trino-plugin/build.gradle
@@ -15,7 +15,9 @@ dependencies {
   implementation (group:'io.airlift', name: 'log', version: '221')
   implementation (group:'com.google.guava', name: 'guava', version: '24.1-jre')
   implementation (group:'io.trino', name: 'trino-plugin-toolkit', version: project.ext.'trino-version')
-  runtimeOnly (group:'io.trino', name: 'trino-main', version: project.ext.'trino-version')
+  runtimeOnly (group:'io.trino', name: 'trino-main', version: project.ext.'trino-version') {
+    exclude 'group': 'io.trino', 'module': 'trino-spi'
+  }
   compileOnly(group:'io.trino', name: 'trino-spi', version: project.ext.'trino-version')
   testImplementation (group:'io.trino', name: 'trino-main', version: project.ext.'trino-version')
 }


### PR DESCRIPTION
## Summary
* The plugin class loader in Trino delegates to the server class loader to handle the namespace `io.trino.spi`. The distribution should not contain `trino-spi` jar.