### PR TITLE
Publish UDF jars for multiple query engines as artifacts with Gradle 7

### DIFF
--- a/transportable-udfs-plugin/src/main/java/com/linkedin/transport/plugin/packaging/ShadedJarPackaging.java
+++ b/transportable-udfs-plugin/src/main/java/com/linkedin/transport/plugin/packaging/ShadedJarPackaging.java
@@ -14,6 +14,7 @@ import com.linkedin.transport.plugin.tasks.ShadeTask;
 import java.util.List;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
+import org.gradle.api.component.AdhocComponentWithVariants;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.bundling.Jar;
@@ -78,8 +79,10 @@ public class ShadedJarPackaging implements Packaging {
           task.exclude("META-INF/INDEX.LIST", "META-INF/*.SF", "META-INF/*.DSA", "META-INF/*.RSA");
         });
 
-    // TODO: Figure out why this artifact is generated but not being published in Maven
-    project.getArtifacts().add(ShadowBasePlugin.getCONFIGURATION_NAME(), shadeTask);
+    String configuration = ShadowBasePlugin.getCONFIGURATION_NAME();
+    project.getArtifacts().add(configuration, shadeTask);
+    AdhocComponentWithVariants java = project.getComponents().withType(AdhocComponentWithVariants.class).getByName("java");
+    java.addVariantsFromConfiguration(project.getConfigurations().getByName(configuration), v -> v.mapToOptional());
     return shadeTask;
   }
 }

--- a/transportable-udfs-trino-plugin/build.gradle
+++ b/transportable-udfs-trino-plugin/build.gradle
@@ -15,7 +15,9 @@ dependencies {
   implementation (group:'io.airlift', name: 'log', version: '221')
   implementation (group:'com.google.guava', name: 'guava', version: '24.1-jre')
   implementation (group:'io.trino', name: 'trino-plugin-toolkit', version: project.ext.'trino-version')
-  runtimeOnly (group:'io.trino', name: 'trino-main', version: project.ext.'trino-version')
+  runtimeOnly (group:'io.trino', name: 'trino-main', version: project.ext.'trino-version') {
+    exclude 'group': 'io.trino', 'module': 'trino-spi'
+  }
   compileOnly(group:'io.trino', name: 'trino-spi', version: project.ext.'trino-version')
   testImplementation (group:'io.trino', name: 'trino-main', version: project.ext.'trino-version')
 }

--- a/version.properties
+++ b/version.properties
@@ -1,3 +1,3 @@
 # Version of the produced binaries.
 # The version is inferred by shipkit-auto-version Gradle plugin (https://github.com/shipkit/shipkit-auto-version)
-version=0.0.*
+version=0.1.*


### PR DESCRIPTION
**Code Change**
- The code changes in `ShadedJarPackaging` to make UDF jars generated for multiple query engines (e.g. hive, spark, and trino) to be published as artifacts with Gradle 7
- The code changes in `transportable-udfs-trino-plugin/build.gradle` to exclude packaging of trino-spi.jar for the plugin

**Test**
./gradlew clean build
cd transportable-udfs-examples
./gradlew clean build