### PR TITLE
Remove some internal Trino API dependencies

### DIFF
--- a/transportable-udfs-trino/src/main/java/com/linkedin/transport/trino/StdUDFUtils.java
+++ b/transportable-udfs-trino/src/main/java/com/linkedin/transport/trino/StdUDFUtils.java
@@ -8,6 +8,9 @@ package com.linkedin.transport.trino;
 import com.google.common.collect.ImmutableSet;
 import com.linkedin.transport.typesystem.TypeSignature;
 import com.linkedin.transport.typesystem.TypeSignatureElement;
+import io.trino.spi.TrinoException;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -15,6 +18,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.linkedin.transport.typesystem.ConcreteTypeSignatureElement.*;
+import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 
 
 /**
@@ -47,6 +51,14 @@ public final class StdUDFUtils {
    */
   static String quoteReservedKeywords(String signature) {
     return toTrinoTypeSignatureString(TypeSignature.parse(signature));
+  }
+
+  public static MethodHandle methodHandle(Class<?> clazz, String name, Class<?>... parameterTypes) {
+    try {
+      return MethodHandles.lookup().unreflect(clazz.getMethod(name, parameterTypes));
+    } catch (IllegalAccessException | NoSuchMethodException e) {
+      throw new TrinoException(GENERIC_INTERNAL_ERROR, e);
+    }
   }
 
   private static String toTrinoTypeSignatureString(TypeSignature typeSignature) {

--- a/transportable-udfs-trino/src/main/java/com/linkedin/transport/trino/StdUdfWrapper.java
+++ b/transportable-udfs-trino/src/main/java/com/linkedin/transport/trino/StdUdfWrapper.java
@@ -54,13 +54,13 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.commons.lang3.ClassUtils;
 
+import static com.linkedin.transport.trino.StdUDFUtils.methodHandle;
 import static com.linkedin.transport.trino.StdUDFUtils.quoteReservedKeywords;
 import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.*;
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.NULLABLE_RETURN;
 import static io.trino.spi.function.OperatorType.*;
 import static io.trino.spi.function.TypeVariableConstraint.*;
 import static io.trino.sql.analyzer.TypeSignatureTranslator.parseTypeSignature;
-import static io.trino.util.Reflection.*;
 
 // Suppressing argument naming convention for the evalInternal methods
 @SuppressWarnings({"checkstyle:regexpsinglelinejava"})

--- a/transportable-udfs-trino/src/main/java/com/linkedin/transport/trino/TrinoFactory.java
+++ b/transportable-udfs-trino/src/main/java/com/linkedin/transport/trino/TrinoFactory.java
@@ -32,7 +32,6 @@ import com.linkedin.transport.trino.data.TrinoStruct;
 import io.airlift.slice.Slices;
 import io.trino.metadata.FunctionBinding;
 import io.trino.spi.function.FunctionDependencies;
-import io.trino.metadata.OperatorNotFoundException;
 import io.trino.spi.function.InvocationConvention;
 import io.trino.spi.function.OperatorType;
 import io.trino.spi.type.ArrayType;
@@ -137,7 +136,7 @@ public class TrinoFactory implements StdFactory {
   public MethodHandle getOperatorHandle(
       OperatorType operatorType,
       List<Type> argumentTypes,
-      InvocationConvention invocationConvention) throws OperatorNotFoundException {
+      InvocationConvention invocationConvention) {
     return functionDependencies.getOperatorImplementation(operatorType, argumentTypes, invocationConvention).getMethodHandle();
   }
 }


### PR DESCRIPTION
## Summary
* Clean up the internal Trino API dependencies that have an easy fix
* Fork the implementation of `Reflection#methodHandle` upstream
* `TrinoFactory#getOperatorHandle` does not throw `OperatorNotFoundException` anymore; previously it does because of [Metadata#resolveOperator](https://github.com/trinodb/trino/blob/352/core/trino-main/src/main/java/io/trino/metadata/Metadata.java#L551); [ref in TrinoFactory](https://github.com/linkedin/transport/blob/v0.0.88/transportable-udfs-trino/src/main/java/com/linkedin/transport/trino/TrinoFactory.java#L156)
* Simplify the use of `ChoicesSpecializedSqlScalarFunction` to only using Trino SPI. `StdUDFWrapper` uses this class in the following manner to get the `ScalarFunctionImplementation`
```
ScalarFunctionImplementation res = new ChoicesSpecializedSqlScalarFunction(
        boundSignature,
        NULLABLE_RETURN,
        getNullConventionForArguments(nullableArguments),
        getMethodHandle(stdUDF, boundSignature, nullableArguments, requiredFilesNextRefreshTime)).getScalarFunctionImplementation(invocationConvention);
```
which is equivalent to a `ChoicesSpecializedSqlScalarFunction` with only one `ScalarImplementationChoice`, also `lambdaInterfaces` and `instanceFactory` are always empty/absent.

Then look at its `getScalarFunctionImplementation` ([code](https://github.com/trinodb/trino/blob/406/core/trino-main/src/main/java/io/trino/operator/scalar/ChoicesSpecializedSqlScalarFunction.java#L101)). Since there is only one choice and the given constraints on `instanceFactory` and `lambdaInterfaces`, this method is equivalent to
```
MethodHandle methodHandle = functionAdapter.adapt(
                bestChoice.getMethodHandle(),
                boundSignature.getArgumentTypes(),
                bestChoice.getInvocationConvention(),
                invocationConvention);
ScalarFunctionImplementation.Builder builder = ScalarFunctionImplementation.builder()
                .methodHandle(methodHandle);
builder.lambdaInterfaces(ImmutableList.of());
return builder.build();
```
Then look at how the only `ScalarImplementationChoice` is constructed [ref](https://github.com/trinodb/trino/blob/406/core/trino-main/src/main/java/io/trino/operator/scalar/ChoicesSpecializedSqlScalarFunction.java#L136), where
```
invocationConvention = new InvocationConvention(
                    argumentConventions,
                    returnConvention,
                    hasSession,
                    instanceFactory.isPresent());
```
can be simplified to the following since Transport does not support session functions.
```
invocationConvention = new InvocationConvention(argumentConventions, returnConvention, false, false);
```