### PR TITLE
Fix packaging task for Trino with Gradle 7

### DIFF
--- a/transportable-udfs-plugin/src/main/java/com/linkedin/transport/plugin/packaging/ThinJarPackaging.java
+++ b/transportable-udfs-plugin/src/main/java/com/linkedin/transport/plugin/packaging/ThinJarPackaging.java
@@ -5,12 +5,13 @@
  */
 package com.linkedin.transport.plugin.packaging;
 
+import com.github.jengelman.gradle.plugins.shadow.ShadowBasePlugin;
 import com.google.common.collect.ImmutableList;
 import com.linkedin.transport.plugin.Platform;
 import java.util.List;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
-import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.component.AdhocComponentWithVariants;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.bundling.Jar;
@@ -42,7 +43,11 @@ public class ThinJarPackaging implements Packaging {
           task.from(platformSourceSet.getResources());
         });
 
-    project.getArtifacts().add(Dependency.ARCHIVES_CONFIGURATION, thinJarTask);
+    String configuration = ShadowBasePlugin.getCONFIGURATION_NAME();
+    project.getArtifacts().add(configuration, thinJarTask);
+    AdhocComponentWithVariants java = project.getComponents().withType(AdhocComponentWithVariants.class).getByName("java");
+    java.addVariantsFromConfiguration(project.getConfigurations().getByName(configuration), v -> v.mapToOptional());
+
     return ImmutableList.of(thinJarTask);
   }
 }


### PR DESCRIPTION
**Code Changes**
- As the jars generated for Trino is generated by the class of `ThinJarPackaging` and `DistributionPackaging`, making some code changes in both classes on how to generate the packaging task, so the jars generated from those packaging task can be published as artifacts with Gradle 7.

**Tests**
cd transport
./gradlew clean build
cd transportable-udfs-example
./gradlew clean build

test a UDF MP (e.g. standard-udfs-marketing) with a locally-built transport-plugin 
mint build
mint release
the content about the artifacts shown in buildspec.json include all jars
```
"artifacts": {
      "marketing-std-udf": "ivy:/com.linkedin.standard-udfs-marketing/marketing-std-udf/1.0.7",
      "marketing-std-udf:hive": "ivy:/com.linkedin.standard-udfs-marketing/marketing-std-udf/1.0.7",
      "marketing-std-udf:javadoc": "ivy:/com.linkedin.standard-udfs-marketing/marketing-std-udf/1.0.7",
      "marketing-std-udf:sources": "ivy:/com.linkedin.standard-udfs-marketing/marketing-std-udf/1.0.7",
      "marketing-std-udf:spark_2.11": "ivy:/com.linkedin.standard-udfs-marketing/marketing-std-udf/1.0.7",
      "marketing-std-udf:spark_2.12": "ivy:/com.linkedin.standard-udfs-marketing/marketing-std-udf/1.0.7",
      "marketing-std-udf:trino-dist-thin": "ivy:/com.linkedin.standard-udfs-marketing/marketing-std-udf/1.0.7",
      "marketing-std-udf:trino-thin": "ivy:/com.linkedin.standard-udfs-marketing/marketing-std-udf/1.0.7"
    }
``` 