### PR TITLE
Publish *-trino.tar(.zip) as an artifact for UDFs generated

### DIFF
--- a/transportable-udfs-plugin/src/main/java/com/linkedin/transport/plugin/packaging/DistributionPackaging.java
+++ b/transportable-udfs-plugin/src/main/java/com/linkedin/transport/plugin/packaging/DistributionPackaging.java
@@ -58,6 +58,7 @@ public class DistributionPackaging implements Packaging {
     // Explicitly set classifiers for the created distributions or else leads to Maven packaging issues due to multiple
     // artifacts with the same classifier
     project.getTasks().named(platform.getName() + "DistTar", Tar.class, tar -> tar.setClassifier(platform.getName()));
+    project.getArtifacts().add("shadow", project.getTasks().named(platform.getName() + "DistTar", Tar.class));
     project.getTasks().named(platform.getName() + "DistZip", Zip.class, zip -> zip.setClassifier(platform.getName()));
     return ImmutableList.of(project.getTasks().named(platform.getName() + "DistTar", Tar.class),
         project.getTasks().named(platform.getName() + "DistZip", Zip.class));

--- a/transportable-udfs-plugin/src/main/java/com/linkedin/transport/plugin/packaging/DistributionPackaging.java
+++ b/transportable-udfs-plugin/src/main/java/com/linkedin/transport/plugin/packaging/DistributionPackaging.java
@@ -58,7 +58,7 @@ public class DistributionPackaging implements Packaging {
     // Explicitly set classifiers for the created distributions or else leads to Maven packaging issues due to multiple
     // artifacts with the same classifier
     project.getTasks().named(platform.getName() + "DistTar", Tar.class, tar -> tar.setClassifier(platform.getName()));
-    project.getArtifacts().add("shadow", project.getTasks().named(platform.getName() + "DistTar", Tar.class));
+    project.getArtifacts().add(ShadowBasePlugin.getCONFIGURATION_NAME(), project.getTasks().named(platform.getName() + "DistTar", Tar.class));
     project.getTasks().named(platform.getName() + "DistZip", Zip.class, zip -> zip.setClassifier(platform.getName()));
     return ImmutableList.of(project.getTasks().named(platform.getName() + "DistTar", Tar.class),
         project.getTasks().named(platform.getName() + "DistZip", Zip.class));

--- a/transportable-udfs-plugin/src/main/java/com/linkedin/transport/plugin/packaging/DistributionPackaging.java
+++ b/transportable-udfs-plugin/src/main/java/com/linkedin/transport/plugin/packaging/DistributionPackaging.java
@@ -11,7 +11,6 @@ import com.linkedin.transport.plugin.Platform;
 import java.util.List;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
-import org.gradle.api.component.AdhocComponentWithVariants;
 import org.gradle.api.distribution.DistributionContainer;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskProvider;

--- a/transportable-udfs-plugin/src/main/java/com/linkedin/transport/plugin/packaging/DistributionPackaging.java
+++ b/transportable-udfs-plugin/src/main/java/com/linkedin/transport/plugin/packaging/DistributionPackaging.java
@@ -60,6 +60,7 @@ public class DistributionPackaging implements Packaging {
     project.getTasks().named(platform.getName() + "DistTar", Tar.class, tar -> tar.setClassifier(platform.getName()));
     project.getArtifacts().add(ShadowBasePlugin.getCONFIGURATION_NAME(), project.getTasks().named(platform.getName() + "DistTar", Tar.class));
     project.getTasks().named(platform.getName() + "DistZip", Zip.class, zip -> zip.setClassifier(platform.getName()));
+    project.getArtifacts().add(ShadowBasePlugin.getCONFIGURATION_NAME(), project.getTasks().named(platform.getName() + "DistZip", Zip.class));
     return ImmutableList.of(project.getTasks().named(platform.getName() + "DistTar", Tar.class),
         project.getTasks().named(platform.getName() + "DistZip", Zip.class));
   }
@@ -84,11 +85,6 @@ public class DistributionPackaging implements Packaging {
       task.from(sourceSet.getOutput());
       task.from(sourceSet.getResources());
     });
-
-    String configuration = ShadowBasePlugin.getCONFIGURATION_NAME();
-    project.getArtifacts().add(configuration, thinJarTask);
-    AdhocComponentWithVariants java = project.getComponents().withType(AdhocComponentWithVariants.class).getByName("java");
-    java.addVariantsFromConfiguration(project.getConfigurations().getByName(configuration), v -> v.mapToOptional());
 
     return thinJarTask;
   }


### PR DESCRIPTION
**Code Change**
- With Gradle 7, the task to generate an build output needs to be added into `project.getArtifacts()` explicitly if the build output needs to be published as an artifact. Therefore in `DistributionPackaging.configurePackagingTasks`,  the task to generate `*-trino.tar` (`*-trino.zip) in as a distribution package are added into `project.getArtifacts()` explicitly
- Remove the task to generate `*-trino-dist-thin.jar` out of `project.getArtifacts()`

**Test**
cd transport
./gradlew clean build

// in a consumer UDF MP
./gradlew clean build
mint release

The resulted artifact list in the file of buildspec.json are as follows:
```

"artifacts": {
      "marketing-std-udf": "ivy:/com.linkedin.standard-udfs-marketing/marketing-std-udf/1.0.7",
      "marketing-std-udf:hive": "ivy:/com.linkedin.standard-udfs-marketing/marketing-std-udf/1.0.7",
      "marketing-std-udf:javadoc": "ivy:/com.linkedin.standard-udfs-marketing/marketing-std-udf/1.0.7",
      "marketing-std-udf:sources": "ivy:/com.linkedin.standard-udfs-marketing/marketing-std-udf/1.0.7",
      "marketing-std-udf:spark_2.11": "ivy:/com.linkedin.standard-udfs-marketing/marketing-std-udf/1.0.7",
      "marketing-std-udf:spark_2.12": "ivy:/com.linkedin.standard-udfs-marketing/marketing-std-udf/1.0.7",
      "marketing-std-udf:trino": "ivy:/com.linkedin.standard-udfs-marketing/marketing-std-udf/1.0.7",
     "marketing-std-udf:zip": "ivy:/com.linkedin.standard-udfs-marketing/marketing-std-udf/1.0.7",
      "marketing-std-udf:trino-thin": "ivy:/com.linkedin.standard-udfs-marketing/marketing-std-udf/1.0.7"
    },
```