### PR TITLE
Fix missing arguments nullability in FunctionMetadata

### DIFF
--- a/transportable-udfs-examples/transportable-udfs-example-udfs/src/test/java/com/linkedin/transport/examples/TestFileLookupFunction.java
+++ b/transportable-udfs-examples/transportable-udfs-example-udfs/src/test/java/com/linkedin/transport/examples/TestFileLookupFunction.java
@@ -13,7 +13,6 @@ import com.linkedin.transport.test.AbstractStdUDFTest;
 import com.linkedin.transport.test.spi.StdTester;
 import java.util.List;
 import java.util.Map;
-import org.testng.Assert;
 import org.testng.annotations.Test;
 
 
@@ -32,16 +31,9 @@ public class TestFileLookupFunction extends AbstractStdUDFTest {
     tester.check(functionCall("file_lookup", null, 1), null, "boolean");
   }
 
-  @Test
+  @Test(expectedExceptions = NullPointerException.class)
   public void testFileLookupFailNull() {
-    try {
-      StdTester tester = getTester();
-      // in case of Trino, the execution of a query with UDF to check a null value in a file
-      // does not result in a NullPointerException, but returns a null value
-      tester.check(functionCall("file_lookup", resource("file_lookup_function/sample"), null), null, "boolean");
-    } catch (NullPointerException ex) {
-      // in case of Hive and Spark, the execution of a query with UDF to check a null value in a file results in a NullPointerException
-      Assert.assertFalse(isTrinoTest());
-    }
+    StdTester tester = getTester();
+    tester.check(functionCall("file_lookup", resource("file_lookup_function/sample"), null), null, "boolean");
   }
 }


### PR DESCRIPTION
## Summary
* Should fix the issues in #149 
* Trino engine does not invoke function when non-nullable arguments receive null value; this is determined by `FunctionMetadata#functionNullability`
* `FunctionMetadata#argumentNullability` expects `Boolean` object
* Revert changes in `TestFileLookUp`, since Trino actually throws `NullPointerException` in this case