### PR TITLE
Add Hadoop libraries as runtimeOnly dependeny in transportable-udfs-test-hive/generic/trino

### DIFF
--- a/transportable-udfs-examples/transportable-udfs-example-udfs/build.gradle
+++ b/transportable-udfs-examples/transportable-udfs-example-udfs/build.gradle
@@ -13,8 +13,6 @@ dependencies {
   implementation('org.apache.commons:commons-io:1.3.2')
   testImplementation('io.airlift:aircompressor:0.21')
   testImplementation('org.junit.jupiter:junit-jupiter-api:5.9.2')
-  testImplementation 'org.apache.hadoop:hadoop-common:2.7.4'
-  testImplementation 'org.apache.hadoop:hadoop-mapreduce-client-core:2.7.4'
 }
 
 // As the tasks of trinoDistThinJar and trinoTrinJar are from Transport plugin which is built by Gradle 7.5.1,

--- a/transportable-udfs-test/transportable-udfs-test-generic/build.gradle
+++ b/transportable-udfs-test/transportable-udfs-test-generic/build.gradle
@@ -9,6 +9,8 @@ dependencies {
   implementation 'org.testng:testng:6.11'
   compileOnly 'org.apache.hadoop:hadoop-common:2.7.4'
   compileOnly 'org.apache.hadoop:hadoop-mapreduce-client-core:2.7.4'
+  runtimeOnly 'org.apache.hadoop:hadoop-common:2.7.4'
+  runtimeOnly 'org.apache.hadoop:hadoop-mapreduce-client-core:2.7.4'
   testImplementation 'org.apache.hadoop:hadoop-common:2.7.4'
   testImplementation 'org.apache.hadoop:hadoop-mapreduce-client-core:2.7.4'
 }

--- a/transportable-udfs-test/transportable-udfs-test-hive/build.gradle
+++ b/transportable-udfs-test/transportable-udfs-test-hive/build.gradle
@@ -13,4 +13,6 @@ dependencies {
   implementation ('org.apache.hive:hive-service:1.2.2') {
     exclude group: 'org.apache.hive', module: 'hive-exec'
   }
+  runtimeOnly 'org.apache.hadoop:hadoop-common:2.7.4'
+  runtimeOnly 'org.apache.hadoop:hadoop-mapreduce-client-core:2.7.4'
 }

--- a/transportable-udfs-test/transportable-udfs-test-trino/build.gradle
+++ b/transportable-udfs-test/transportable-udfs-test-trino/build.gradle
@@ -22,4 +22,6 @@ dependencies {
   // If not specified, an older version is picked up transitively from another dependency
   implementation(group: 'io.airlift', name: 'slice', version: project.ext.'airlift-slice-version')
   implementation(group: 'org.assertj', name: 'assertj-core', version: '3.24.2')
+  runtimeOnly 'org.apache.hadoop:hadoop-common:2.7.4'
+  runtimeOnly 'org.apache.hadoop:hadoop-mapreduce-client-core:2.7.4'
 }


### PR DESCRIPTION
**Code Changes**
As consumer UDFs generated by Transport Plugin use `HiveTester` defined in the module of `transportable-udfs-hive-test` to execute the unit tests on UDF generated against Hive at run time and `HiveTester` depends on some classes from the libraries of `hadoop-common` and `hadoop-mapreduce-client-core`, two libraries are required at run time and they are added as `runtimeOnly` dependencies in the module of `transportable-udfs-hive-test`.
Also the test classes from `transportable-udfs-test-generic` and `transportable-udfs-test-trino` depends on hdfs library of Hadoop when the tests of UDF are executed at runtime. Therefore the runtimeOnly dependencies on two libraries are added into `transportable-udfs-test-generic` and `transportable-udfs-test-trino`. 

**Tests**
```
cd transport
./gradlew clean build

cd transportable-udfs-examples
./gradlew clean build

Test UDF with a locally-built TransportPlugin with this code change. 
```