### PR TITLE
Delegate hadoop to plugin classloader

### DIFF
--- a/transportable-udfs-trino-plugin/build.gradle
+++ b/transportable-udfs-trino-plugin/build.gradle
@@ -18,8 +18,10 @@ dependencies {
   runtimeOnly (group:'io.trino', name: 'trino-main', version: project.ext.'trino-version') {
     exclude 'group': 'io.trino', 'module': 'trino-spi'
   }
-  compileOnly(group:'io.trino', name: 'trino-spi', version: project.ext.'trino-version')
+  compileOnly (group:'io.trino', name: 'trino-spi', version: project.ext.'trino-version')
   testImplementation (group:'io.trino', name: 'trino-main', version: project.ext.'trino-version')
+  testImplementation ('org.apache.hadoop:hadoop-common:2.7.4')
+  testImplementation ('org.apache.hadoop:hadoop-mapreduce-client-core:2.7.4')
 }
 
 // packaging as a shaded jar following the guideline from Trino plugin

--- a/transportable-udfs-trino-plugin/src/main/java/com/linkedin/transport/trino/TransportUDFClassLoader.java
+++ b/transportable-udfs-trino-plugin/src/main/java/com/linkedin/transport/trino/TransportUDFClassLoader.java
@@ -39,7 +39,8 @@ public class TransportUDFClassLoader extends URLClassLoader {
       }
 
       if (name.equals("com.linkedin.transport.trino.StdUdfWrapper")
-          || name.startsWith("com.linkedin.transport.api")) {
+          || name.startsWith("com.linkedin.transport.api")
+          || name.startsWith("org.apache.hadoop")) {
         return resolveClass(parent.loadClass(name), resolve);
       }
 


### PR DESCRIPTION
## Summary
* `StdUdfWrapper` depends on some Hadoop-related classes. We are letting the plugin-level class loader to load it, hence transitively also loads the Hadoop classes.
* Some client UDF classes may also depend on the Hadoop classes. We need to explicitly delegate the loading of such classes back to the parent to avoid conflicts.

## Testing Done
* Tested in a Trino cluster