### PR TITLE
Fix Bug in Trino Map ValueType

### DIFF
--- a/transportable-udfs-trino/src/main/java/com/linkedin/transport/trino/types/TrinoMapType.java
+++ b/transportable-udfs-trino/src/main/java/com/linkedin/transport/trino/types/TrinoMapType.java
@@ -26,7 +26,7 @@ public class TrinoMapType implements StdMapType {
 
   @Override
   public StdType valueType() {
-    return TrinoWrapper.createStdType(mapType.getKeyType());
+    return TrinoWrapper.createStdType(mapType.getValueType());
   }
 
   @Override


### PR DESCRIPTION
valueType() should return the valueType instead of the keytype of the map