### PR TITLE
Add task dependency

### DIFF
--- a/transportable-udfs-plugin/build.gradle
+++ b/transportable-udfs-plugin/build.gradle
@@ -126,3 +126,7 @@ publishing {
   //useful for testing - running "publish" will create artifacts/pom in a local dir
   repositories { maven { url = "$rootProject.buildDir/repo" } }
 }
+
+tasks.named("publishPluginMavenPublicationToSonatypeRepository").configure {
+  dependsOn(tasks.named("signSimplePluginPluginMarkerMavenPublication"))
+}

--- a/transportable-udfs-plugin/build.gradle
+++ b/transportable-udfs-plugin/build.gradle
@@ -127,6 +127,13 @@ publishing {
   repositories { maven { url = "$rootProject.buildDir/repo" } }
 }
 
-tasks.named("publishPluginMavenPublicationToSonatypeRepository").configure {
-  dependsOn(tasks.named("signSimplePluginPluginMarkerMavenPublication"))
+import org.gradle.api.publish.maven.tasks.PublishToMavenRepository
+
+if (providers.environmentVariable("PGP_KEY").isPresent()) {
+  tasks.withType(PublishToMavenRepository).configureEach { pubTask ->
+    if (pubTask.name.startsWith("publishPluginMavenPublicationTo")) {
+      dependsOn(tasks.named("signSimplePluginPluginMarkerMavenPublication"))
+    }
+  }
 }
+


### PR DESCRIPTION
Fix for this error :

Reason: Task ':transportable-udfs-plugin:publishPluginMavenPublicationToSonatypeRepository' uses this output of task ':transportable-udfs-plugin:signSimplePluginPluginMarkerMavenPublication' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.