### PR TITLE
Fix hotfix release tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,18 +53,14 @@ jobs:
           PGP_KEY: ${{secrets.PGP_KEY}}
           PGP_PWD: ${{secrets.PGP_PWD}}
 
-      - name: 5. Derive version for hotfix
-        if: github.ref == 'refs/heads/1.0.1-hotfix'
-        run: echo "DERIVED_VERSION=1.0.1-hotfix" >> $GITHUB_ENV
-
-      - name: 6. Perform release for hotfix branch if commit is this branch
+      - name: 5. Perform release for hotfix branch if commit is this branch
         # Release job, only for pushes to the main development branch
         if: github.event_name == 'push'
           && github.ref == 'refs/heads/1.0.1-hotfix'
           && github.repository == 'linkedin/transport'
           && !contains(toJSON(github.event.commits.*.message), '[skip release]')
 
-        run: ./gradlew githubRelease publishToSonatype closeAndReleaseStagingRepository -Pversion="${{ env.DERIVED_VERSION }}"
+        run: ./gradlew githubRelease publishToSonatype closeAndReleaseStagingRepository
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
           SONATYPE_TOKEN_USERNAME: ${{secrets.SONATYPE_TOKEN_USERNAME}}

--- a/version.properties
+++ b/version.properties
@@ -1,3 +1,4 @@
 # Version of the produced binaries.
 # The version is inferred by shipkit-auto-version Gradle plugin (https://github.com/shipkit/shipkit-auto-version)
 version=0.1.*
+tagPrefix=v-hotfix-


### PR DESCRIPTION
Fix for below error 👍 
* What went wrong:
Execution failed for task ':githubRelease'.
> Unable to post release to Github.
    * url: https://api.github.com/repos/linkedin/transport/releases
    * release tag: v1.0.1-hotfix
    * release name: v1.0.1-hotfix
    * token: ghs...
    * content:
  <sup><sup>*Changelog generated by [Shipkit Changelog Gradle Plugin](https://github.com/shipkit/shipkit-changelog)*</sup></sup>
  
  #### 1.0.1-hotfix
   - 2025-10-17 - [4 commit(s)](https://github.com/linkedin/transport/compare/v0.1.12...v1.0.1-hotfix) by ramurm2013-droid
   - Add task dependency [(#167)](https://github.com/linkedin/transport/pull/167)
   - Fix publish url [(#166)](https://github.com/linkedin/transport/pull/166)
   - Add gradle.properties [(#160)](https://github.com/linkedin/transport/pull/160)
   - Upgrade Transport to work with Trino V446 [(#159)](https://github.com/linkedin/transport/pull/159)
  
    * underlying problem: POST https://api.github.com/repos/linkedin/transport/releases failed, response code = 422, response body:
  {"message":"Validation Failed","errors":[{"resource":"Release","code":"already_exists","field":"tag_name"}],"documentation_url":"https://docs.github.com/rest/releases/releases#create-a-release","status":"422"}