### PR TITLE
Fix publish dependency error

### DIFF
--- a/transportable-udfs-plugin/build.gradle
+++ b/transportable-udfs-plugin/build.gradle
@@ -81,7 +81,7 @@ publishing {
   // creates its publications in an afterEvaluate callback
   afterEvaluate {
     publications {
-      withType(MavenPublication) {
+      named("pluginMaven", MavenPublication) {
         artifact sourcesJar
         artifact javadocJar
 
@@ -125,15 +125,5 @@ publishing {
 
   //useful for testing - running "publish" will create artifacts/pom in a local dir
   repositories { maven { url = "$rootProject.buildDir/repo" } }
-}
-
-import org.gradle.api.publish.maven.tasks.PublishToMavenRepository
-
-if (providers.environmentVariable("PGP_KEY").isPresent()) {
-  tasks.withType(PublishToMavenRepository).configureEach { pubTask ->
-    if (pubTask.name.startsWith("publishPluginMavenPublicationTo")) {
-      dependsOn(tasks.named("signSimplePluginPluginMarkerMavenPublication"))
-    }
-  }
 }
 


### PR DESCRIPTION
Error :

Reason: Task ':transportable-udfs-plugin:publishSimplePluginPluginMarkerMavenPublicationToSonatypeRepository' uses this output of task ':transportable-udfs-plugin:signPluginMavenPublication' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.


Fix 👍 

By scoping the artifacts & POM only to pluginMaven, there are no overlapping files to sign/publish, so Gradle’s “uses output without dependency” complaint disappears.