### PR TITLE
Fix closeSonatypeStagingRepository

### DIFF
--- a/transportable-udfs-plugin/build.gradle
+++ b/transportable-udfs-plugin/build.gradle
@@ -120,6 +120,30 @@ publishing {
           }
         }
       }
+
+      named("simplePluginPluginMarkerMaven", MavenPublication) {
+        pom {
+          name = "Transport Gradle Plugin (Marker)"
+          description = "Marker artifact for the 'com.linkedin.transport.plugin' Gradle plugin"
+          url = "https://github.com/linkedin/transport"
+          licenses {
+            license {
+              name = "BSD 2-CLAUSE LICENSE"
+              url = "https://github.com/linkedin/transport/blob/master/LICENSE"
+              distribution = "repo"
+            }
+          }
+          developers {
+            developer { id = "wmoustafa"; name = "Walaa Eldin Moustafa" }
+            developer { id = "shardulm94"; name = "Shardul Mahadik" }
+          }
+          scm {
+            connection = "scm:git:https://github.com/linkedin/transport.git"
+            developerConnection = "scm:git:ssh://git@github.com/linkedin/transport.git"
+            url = "https://github.com/linkedin/transport"
+          }
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Error : 
* What went wrong:
Execution failed for task ':closeSonatypeStagingRepository'.

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.
> Failed to close staging repository, server at https://ossrh-staging-api.central.sonatype.com/service/local/ responded with status code 400, body: Failed to process request: Deployment reached an unexpected status: Failed
  pkg:maven/com.linkedin.transport.plugin/com.linkedin.transport.plugin.gradle.plugin@0.1.18

  - Project name is missing
  - Project description is missing
  - Project URL is not defined
  - License information is missing
  - SCM URL is not defined
  - Developers information is missing