### PR TITLE
Upgrade spark_2.11 to 2.4.6

### DIFF
--- a/defaultEnvironment.gradle
+++ b/defaultEnvironment.gradle
@@ -10,6 +10,6 @@ subprojects {
   project.ext.setProperty('trino-version', '446')
   project.ext.setProperty('airlift-slice-version', '0.44')
   project.ext.setProperty('spark-group', 'org.apache.spark')
-  project.ext.setProperty('spark2-version', '2.3.0')
+  project.ext.setProperty('spark2-version', '2.4.6')
   project.ext.setProperty('spark3-version', '3.1.1')
 }

--- a/transportable-udfs-plugin/build.gradle
+++ b/transportable-udfs-plugin/build.gradle
@@ -24,7 +24,7 @@ def writeVersionInfo = { file ->
     entry(key: "transport-version", value: version)
     entry(key: "hive-version", value: '1.2.2')
     entry(key: "trino-version", value: '446')
-    entry(key: "spark_2.11-version", value: '2.3.0')
+    entry(key: "spark_2.11-version", value: '2.4.6')
     entry(key: "spark_2.12-version", value: '3.1.1')
     entry(key: "scala-version", value: '2.11.8')
   }


### PR DESCRIPTION
ELR FOR com.linkedin.transport:transportable-udfs-test-spark_2.11:0.1.21 started failing at validation step due to below vulnerability. Suggested fix is to update org.apache.spark:spark-parent_2.11 from 2.3.0 to 2.4.6 


org.apache.spark:spark-parent_2.11:2.3.0
Notes: Vulnerability found and is blocked by oss-canary: vulnerability: In Apache Spark 2.4.5 and earlier, a standalone resource manager's master may be configured to require authentication (spark.authenticate) via a shared secret. When enabled, however, a specially-crafted RPC to the master can succeed in starting an application's resources on the Spark cluster, even without the shared key. This can be leveraged to execute shell commands on the host machine. This does not affect Spark clusters using other resource managers (YARN, Mesos, etc). remediation: Refer to the links for remediation. vulnerability: In Apache Spark 2.4.5 and earlier, a standalone resource manager's master may be configured to require authentication (spark.authenticate) via a shared secret. When enabled, however, a specially-crafted RPC to the master can succeed in starting an application's resources on the Spark cluster, even without the shared key. This can be leveraged to execute shell commands on the host machine. This does not affect Spark clusters using other resource managers (YARN, Mesos, etc). remediation: Upgrade org.apache.spark:spark-parent_2.11 from 2.3.0 to 2.4.6 to fix the vulnerability.