### PR TITLE
Upgrade Hive client to 2.3.9 and HIVE platform JDK toolchain to 17

### DIFF
--- a/transportable-udfs-hive/build.gradle
+++ b/transportable-udfs-hive/build.gradle
@@ -5,14 +5,16 @@ dependencies {
   implementation project(':transportable-udfs-api')
   implementation project(':transportable-udfs-utils')
   implementation 'org.apache.hadoop:hadoop-common:2.7.4'
-  compileOnly('org.apache.hive:hive-exec:1.2.2') {
+  compileOnly('org.apache.hive:hive-exec:2.3.9') {
     exclude group: 'org.apache.avro'
     exclude group: 'org.apache.calcite'
+    exclude group: 'org.pentaho'
   }
   testImplementation project(path: ':transportable-udfs-type-system', configuration: 'tests')
-  testImplementation('org.apache.hive:hive-exec:1.2.2') {
+  testImplementation('org.apache.hive:hive-exec:2.3.9') {
     exclude group: 'org.apache.avro'
     exclude group: 'org.apache.calcite'
+    exclude group: 'org.pentaho'
   }
 }
 
@@ -29,4 +31,21 @@ configurations {
 
 artifacts {
   tests jarTests
+}
+
+// Hive 2.3.9's ObjectInspectorFactory uses reflection on java.* internals that JDK 17 modularizes.
+// Open the modules it touches when this subproject's tests run on JDK 17+. Limited to this subproject
+// because no other transport subproject loads Hive 2.3.9 classes in its tests.
+test {
+  if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17)) {
+    jvmArgs '--add-opens=java.base/java.lang=ALL-UNNAMED',
+            '--add-opens=java.base/java.lang.invoke=ALL-UNNAMED',
+            '--add-opens=java.base/java.io=ALL-UNNAMED',
+            '--add-opens=java.base/java.net=ALL-UNNAMED',
+            '--add-opens=java.base/java.nio=ALL-UNNAMED',
+            '--add-opens=java.base/java.util=ALL-UNNAMED',
+            '--add-opens=java.base/java.util.concurrent=ALL-UNNAMED',
+            '--add-opens=java.base/sun.nio.ch=ALL-UNNAMED',
+            '--add-opens=java.base/sun.security.action=ALL-UNNAMED'
+  }
 }

--- a/transportable-udfs-plugin/build.gradle
+++ b/transportable-udfs-plugin/build.gradle
@@ -22,7 +22,7 @@ dependencies {
 def writeVersionInfo = { file ->
   ant.propertyfile(file: file) {
     entry(key: "transport-version", value: version)
-    entry(key: "hive-version", value: '1.2.2')
+    entry(key: "hive-version", value: '2.3.9')
     entry(key: "trino-version", value: '406')
     entry(key: "spark_2.11-version", value: '2.3.0')
     entry(key: "spark_2.12-version", value: '3.1.1')

--- a/transportable-udfs-plugin/src/main/java/com/linkedin/transport/plugin/Defaults.java
+++ b/transportable-udfs-plugin/src/main/java/com/linkedin/transport/plugin/Defaults.java
@@ -90,10 +90,11 @@ class Defaults {
       new Platform(HIVE,
           Language.JAVA,
           HiveWrapperGenerator.class,
-          JavaLanguageVersion.of(8),
+          JavaLanguageVersion.of(17),
           ImmutableList.of(
               DependencyConfiguration.builder(IMPLEMENTATION, "com.linkedin.transport:transportable-udfs-hive", TRANSPORT_VERSION).build(),
-              DependencyConfiguration.builder(COMPILE_ONLY, "org.apache.hive:hive-exec", HIVE_VERSION).exclude("org.apache.calcite").build()
+              DependencyConfiguration.builder(COMPILE_ONLY, "org.apache.hive:hive-exec", HIVE_VERSION)
+                  .exclude("org.apache.calcite").exclude("org.pentaho").build()
           ),
           ImmutableList.of(
               DependencyConfiguration.builder(RUNTIME_ONLY, "com.linkedin.transport:transportable-udfs-test-hive", TRANSPORT_VERSION).build()

--- a/transportable-udfs-plugin/src/main/java/com/linkedin/transport/plugin/TransportPlugin.java
+++ b/transportable-udfs-plugin/src/main/java/com/linkedin/transport/plugin/TransportPlugin.java
@@ -204,6 +204,17 @@ public class TransportPlugin implements Plugin<Project> {
             task.getJavaCompiler().set(javaToolchains.compilerFor(toolChainSpec -> {
               toolChainSpec.getLanguageVersion().set(platform.getJavaLanguageVersion());
             }));
+            // For Hive/Spark: pin bytecode to Java 8 (release=8) so UDF jars stay runnable on
+            // Java 8 runtimes. Trino is excluded because Trino 406+ requires Java 17 bytecode
+            // (uses sealed classes, records, etc.).
+            // Some build environments already configure the bytecode target by passing a
+            // "--release" compiler argument. Gradle forbids specifying --release through both
+            // compilerArgs and JavaCompile.release, so only set the release here when it has
+            // not already been configured externally.
+            if (!"trino".equals(platform.getName())
+                && !task.getOptions().getCompilerArgs().contains("--release")) {
+              task.getOptions().getRelease().set(8);
+            }
           });
     }
 
@@ -278,6 +289,22 @@ public class TransportPlugin implements Plugin<Project> {
       task.getJavaLauncher().set(javaToolchains.launcherFor(toolChainSpec -> {
         toolChainSpec.getLanguageVersion().set(platform.getJavaLanguageVersion());
       }));
+
+      // When the test JVM is JDK 17 (e.g. hiveTest once its toolchain bumps from 8 to 17),
+      // Hive 2.3.9's embedded HiveServer2 + DataNucleus + Derby need extra --add-opens to access
+      // internals that JDK 17 modularizes.
+      if (platform.getJavaLanguageVersion().asInt() >= 17 && !"trino".equals(platform.getName())) {
+        task.jvmArgs(
+            "--add-opens=java.base/java.lang=ALL-UNNAMED",
+            "--add-opens=java.base/java.lang.invoke=ALL-UNNAMED",
+            "--add-opens=java.base/java.io=ALL-UNNAMED",
+            "--add-opens=java.base/java.net=ALL-UNNAMED",
+            "--add-opens=java.base/java.nio=ALL-UNNAMED",
+            "--add-opens=java.base/java.util=ALL-UNNAMED",
+            "--add-opens=java.base/java.util.concurrent=ALL-UNNAMED",
+            "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED",
+            "--add-opens=java.base/sun.security.action=ALL-UNNAMED");
+      }
     });
   }
 

--- a/transportable-udfs-plugin/src/main/java/com/linkedin/transport/plugin/packaging/DistributionPackaging.java
+++ b/transportable-udfs-plugin/src/main/java/com/linkedin/transport/plugin/packaging/DistributionPackaging.java
@@ -56,9 +56,9 @@ public class DistributionPackaging implements Packaging {
 
     // Explicitly set classifiers for the created distributions or else leads to Maven packaging issues due to multiple
     // artifacts with the same classifier
-    project.getTasks().named(platform.getName() + "DistTar", Tar.class, tar -> tar.setClassifier(platform.getName()));
+    project.getTasks().named(platform.getName() + "DistTar", Tar.class, tar -> tar.getArchiveClassifier().set(platform.getName()));
     project.getArtifacts().add(ShadowBasePlugin.CONFIGURATION_NAME, project.getTasks().named(platform.getName() + "DistTar", Tar.class));
-    project.getTasks().named(platform.getName() + "DistZip", Zip.class, zip -> zip.setClassifier(platform.getName()));
+    project.getTasks().named(platform.getName() + "DistZip", Zip.class, zip -> zip.getArchiveClassifier().set(platform.getName()));
     project.getArtifacts().add(ShadowBasePlugin.CONFIGURATION_NAME, project.getTasks().named(platform.getName() + "DistZip", Zip.class));
     return ImmutableList.of(project.getTasks().named(platform.getName() + "DistTar", Tar.class),
         project.getTasks().named(platform.getName() + "DistZip", Zip.class));
@@ -80,7 +80,7 @@ public class DistributionPackaging implements Packaging {
       task.dependsOn(project.getTasks().named(sourceSet.getClassesTaskName()));
       task.setDescription("Assembles a thin jar archive containing the " + platformName
           + " classes to be included in the distribution");
-      task.setClassifier(platformName + "-dist-thin");
+      task.getArchiveClassifier().set(platformName + "-dist-thin");
       task.from(sourceSet.getOutput());
       task.from(sourceSet.getResources());
     });

--- a/transportable-udfs-plugin/src/main/java/com/linkedin/transport/plugin/packaging/ShadedJarPackaging.java
+++ b/transportable-udfs-plugin/src/main/java/com/linkedin/transport/plugin/packaging/ShadedJarPackaging.java
@@ -71,7 +71,7 @@ public class ShadedJarPackaging implements Packaging {
         project.getTasks().register(sourceSet.getTaskName("shade", "Jar"), ShadeTask.class, task -> {
           task.setGroup(ShadowJavaPlugin.SHADOW_GROUP);
           task.setDescription("Create a combined JAR of " + platform.getName() + " output and runtime dependencies");
-          task.setClassifier(platform.getName());
+          task.getArchiveClassifier().set(platform.getName());
           task.getManifest()
               .inheritFrom(project.getTasks().named(mainSourceSet.getJarTaskName(), Jar.class).get().getManifest());
           task.from(sourceSet.getOutput());

--- a/transportable-udfs-plugin/src/main/java/com/linkedin/transport/plugin/packaging/ThinJarPackaging.java
+++ b/transportable-udfs-plugin/src/main/java/com/linkedin/transport/plugin/packaging/ThinJarPackaging.java
@@ -38,7 +38,7 @@ public class ThinJarPackaging implements Packaging {
           task.dependsOn(project.getTasks().named(platformSourceSet.getClassesTaskName()));
           task.setDescription("Assembles a thin jar archive containing the " + platform.getName()
               + " classes to be included in the distribution");
-          task.setClassifier(platform.getName() + "-thin");
+          task.getArchiveClassifier().set(platform.getName() + "-thin");
           task.from(platformSourceSet.getOutput());
           task.from(platformSourceSet.getResources());
         });

--- a/transportable-udfs-test/transportable-udfs-test-hive/build.gradle
+++ b/transportable-udfs-test/transportable-udfs-test-hive/build.gradle
@@ -7,11 +7,15 @@ dependencies {
   implementation ('org.apache.calcite:calcite-core:1.2.0-incubating') {
     exclude group: 'org.pentaho', module: 'pentaho-aggdesigner-algorithm'
   }
-  implementation ('org.apache.hive:hive-exec:1.2.2') {
+  implementation ('org.apache.hive:hive-exec:2.3.9') {
     exclude group: 'org.apache.calcite'
+    exclude group: 'org.pentaho'
   }
-  implementation ('org.apache.hive:hive-service:1.2.2') {
+  implementation ('org.apache.hive:hive-service:2.3.9') {
     exclude group: 'org.apache.hive', module: 'hive-exec'
+    exclude group: 'org.pentaho'
+    exclude group: 'org.apache.twill'
+    exclude group: 'co.cask.tephra'
   }
   runtimeOnly 'org.apache.hadoop:hadoop-common:2.7.4'
   runtimeOnly 'org.apache.hadoop:hadoop-mapreduce-client-core:2.7.4'

--- a/transportable-udfs-test/transportable-udfs-test-hive/src/main/java/com/linkedin/transport/test/hive/HiveTester.java
+++ b/transportable-udfs-test/transportable-udfs-test-hive/src/main/java/com/linkedin/transport/test/hive/HiveTester.java
@@ -57,7 +57,10 @@ public class HiveTester implements SqlStdTester {
 
   private void createHiveServer() {
     HiveServer2 server = new HiveServer2();
-    server.init(new HiveConf());
+    HiveConf conf = new HiveConf();
+    conf.setBoolVar(HiveConf.ConfVars.METASTORE_SCHEMA_VERIFICATION, false);
+    conf.set("datanucleus.schema.autoCreateAll", "true");
+    server.init(conf);
     for (Service service : server.getServices()) {
       if (service instanceof CLIService) {
         _client = (CLIService) service;
@@ -91,7 +94,7 @@ public class HiveTester implements SqlStdTester {
         String functionName =
             ((TopLevelStdUDF) stdUDFImplementations.get(0).getConstructor().newInstance()).getFunctionName();
         _functionRegistryAddFunctionMethod.invoke(_functionRegistry, functionName,
-            new FunctionInfo(false, functionName, wrapper));
+            new FunctionInfo(FunctionInfo.FunctionType.PERSISTENT, functionName, wrapper));
       } catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException | InstantiationException e) {
         throw new RuntimeException("Error registering UDF " + topLevelStdUDF.getName() + " with Hive Server", e);
       }


### PR DESCRIPTION
## Summary

Bumps the plugin's pinned Hive client `1.2.2 → 2.3.9` and the HIVE platform's JDK toolchain `8 → 17` in `Defaults.java`. Bytecode for the HIVE platform stays at Java 8 (`options.release.set(8)`) so the produced consumer UDF jars remain runnable on Java 8 runtimes.

Spark (`spark_2.11`, `spark_2.12`) and Trino subprojects are not changed.

## Motivation

- Hive `1.2.2` transitively pulls `org.pentaho:pentaho-aggdesigner-algorithm:5.1.5-jhyde`, which is not resolvable on Maven Central; downstream builds that don't add an explicit exclusion fail to resolve. Hive `2.3.9` is excludable cleanly.
- Hive `1.2.2`'s embedded HiveServer2 + DataNucleus + Derby reflection paths fail under JDK 17. Hive `2.3.9` is JDK-17-friendly with the standard `--add-opens` flags applied here.
- Net result: downstream UDF projects can move their build JVM to Java 17 without per-project workaround patches for Hive itself.

## Changes

- [`Defaults.java`](https://github.com/YogeshKothari26/transport/blob/yokothar/transport-hive-2.3.9-jdk17/transportable-udfs-plugin/src/main/java/com/linkedin/transport/plugin/Defaults.java#L90-L101): HIVE platform `JavaLanguageVersion.of(8) → of(17)` + add `org.pentaho` exclusion to the consumer's `hive-exec` `compileOnly` configuration.
- [`TransportPlugin.java`](https://github.com/YogeshKothari26/transport/blob/yokothar/transport-hive-2.3.9-jdk17/transportable-udfs-plugin/src/main/java/com/linkedin/transport/plugin/TransportPlugin.java): pin bytecode `release = 8` for non-Trino Java platforms; add `--add-opens` JVM args to the test launcher when the platform's JLV is `>= 17` and the platform is non-Trino.
- [`transportable-udfs-plugin/build.gradle`](https://github.com/YogeshKothari26/transport/blob/yokothar/transport-hive-2.3.9-jdk17/transportable-udfs-plugin/build.gradle): `hive-version 1.2.2 → 2.3.9` in the generated `version-info.properties`.
- [`transportable-udfs-hive/build.gradle`](https://github.com/YogeshKothari26/transport/blob/yokothar/transport-hive-2.3.9-jdk17/transportable-udfs-hive/build.gradle): `hive-exec 1.2.2 → 2.3.9` (`compileOnly` + `testImplementation`), add `org.pentaho` exclusion, add `--add-opens` to the subproject's own test task when the build JVM is JDK 17.
- [`transportable-udfs-test-hive/build.gradle`](https://github.com/YogeshKothari26/transport/blob/yokothar/transport-hive-2.3.9-jdk17/transportable-udfs-test/transportable-udfs-test-hive/build.gradle): `hive-exec` / `hive-service 1.2.2 → 2.3.9`, add `org.pentaho` exclusion.
- [`HiveTester.java`](https://github.com/YogeshKothari26/transport/blob/yokothar/transport-hive-2.3.9-jdk17/transportable-udfs-test/transportable-udfs-test-hive/src/main/java/com/linkedin/transport/test/hive/HiveTester.java): two Hive 2.x compat fixes — replace the removed `FunctionInfo(boolean, String, GenericUDF)` ctor with `FunctionInfo(FunctionType.PERSISTENT, ...)`; disable `METASTORE_SCHEMA_VERIFICATION` and enable `datanucleus.schema.autoCreateAll` on the embedded `HiveConf` (Hive 2.3.x's embedded Derby strictly verifies schema version on startup).

## Testing

### 1. End-to-end Spark integration

A Spark cluster job registers Hive UDFs built by this plugin snapshot and runs SQL queries that exercise:

- Scalar in / out — `StdString` upper-case with null and empty-string edge cases.
- Multi-arg primitives — 2-arg `StdLong` addition with null-argument propagation.
- Complex output — `StdMap<StdString,StdString>` construction with key-lookup, size, and null-key cases.

All cases registered via `CREATE TEMPORARY FUNCTION` + `SELECT` against a `SparkSession`. Exercises driver↔executor serialization, Spark's Hive UDF compatibility shim, and metastore-backed function registration end-to-end. All test cases pass.

### 2. JAR diff vs `master`

SHA-256 + size + class-set + bytecode-major-version on the 7 shipped plugin artifacts (snapshot vs baseline 0.2.0):

- 5 of 7 plugin jars are `CONTENT_IDENTICAL` (every class file byte-identical; zip metadata drift only). The 2 jars with deliberate content change are `transportable-udfs-plugin.jar` (the toolchain wiring) and `transportable-udfs-test-hive.jar` (the Hive 2.x call-site fixes) — i.e. only the files this PR touches.
- `version-info.properties` flips `hive-version=1.2.2 → 2.3.9` as intended.
- Hive UDF wrapper class file confirmed `major version: 52` via `javap -v` (Java 8 bytecode target — preserves Java 8 runtime compatibility). Trino wrapper unchanged at `major version: 61`.

### 3. Plugin example UDFs (build + unit)

`./gradlew build test` on the PR branch — 51 / 51 example tests pass (17 `hiveTest` on JDK 17 launcher, 17 `trinoTest`, 17 generic) across `transportable-udfs-examples` covering every StdUDF arity + Std type (primitives, StdArray, StdMap, StdStruct, nested). Build is green on both JDK 8 and JDK 17 build JVMs.

## Note for consumers bumping their build JVM to JDK 17

The Spark platforms (`spark_2.11`, `spark_2.12`) intentionally stay at `JavaLanguageVersion.of(8)` because Spark `3.1.1` hits [SPARK-33772](https://issues.apache.org/jira/browse/SPARK-33772) on JDK 17. If you bump your build JVM to JDK 17 and use either Spark platform, keep a JDK 8 toolchain reachable from Gradle (e.g., add its path to `org.gradle.java.installations.paths` in your `gradle.properties`). The HIVE platform itself needs no consumer-side workaround. This pin lifts once the plugin's pinned Spark version is bumped to 3.5.x.
