### PR TITLE
Fix malformed Jamon runtime dependency

### DIFF
--- a/transportable-udfs-test/transportable-udfs-test-hive/build.gradle
+++ b/transportable-udfs-test/transportable-udfs-test-hive/build.gradle
@@ -13,10 +13,13 @@ dependencies {
   }
   implementation ('org.apache.hive:hive-service:2.3.9') {
     exclude group: 'org.apache.hive', module: 'hive-exec'
+    exclude group: 'org.jamon', module: 'jamon-runtime'
     exclude group: 'org.pentaho'
     exclude group: 'org.apache.twill'
     exclude group: 'co.cask.tephra'
   }
+  // Hive 2.3.9 pins jamon-runtime 2.3.1, whose published POM is malformed.
+  implementation 'org.jamon:jamon-runtime:2.4.1'
   runtimeOnly 'org.apache.hadoop:hadoop-common:2.7.4'
   runtimeOnly 'org.apache.hadoop:hadoop-mapreduce-client-core:2.7.4'
 }


### PR DESCRIPTION
# Summary

- Exclude `org.jamon:jamon-runtime:2.3.1` from the Hive 2.3.9 service dependency.
- Add `org.jamon:jamon-runtime:2.4.1` directly so the Hive test runtime retains Jamon with valid published metadata.
- Keep the change scoped to `transportable-udfs-test-hive`; production Transport modules are unchanged.

# Why

Hive 2.3.9 declares `jamon-runtime:2.3.1`, whose Maven Central POM contains a duplicate nested `project` element. The malformed POM fails to parse during dependency resolution for `transportable-udfs-test-hive`.

Jamon 2.4.1 provides the same runtime library with a valid POM. Excluding the malformed transitive coordinate and declaring 2.4.1 directly also prevents downstream consumers from traversing the broken metadata.

# Testing Done

- [x] Local code review completed
- [x] `./gradlew clean build` on JDK 8
- [x] Dependency insight resolves only `org.jamon:jamon-runtime:2.4.1`
- [x] Generated Maven publication POM excludes Jamon from `hive-service` and declares 2.4.1 directly
- [x] Local Maven publication completes without a 2.3.1 reference